### PR TITLE
Test/ella week11

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,7 @@ dependencies {
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+    testImplementation 'org.springframework.security:spring-security-test'
 }
 
 tasks.named('test') {
@@ -81,6 +82,15 @@ jacocoTestCoverageVerification {
         rule {
             enabled = true
             element = 'CLASS'
+
+            excludes = [
+                    'com.example.ktb3community.common.*',
+                    'com.example.ktb3community.*.exception.*',
+                    'com.example.ktb3community.*.dto.*',
+                    'com.example.ktb3community.*.mapper.*',
+                    'com.example.ktb3community.config.*',
+                    'com.example.ktb3community.Ktb3CommunityApplication'
+            ]
 
             limit {
                 counter = 'METHOD'

--- a/build.gradle
+++ b/build.gradle
@@ -51,6 +51,19 @@ dependencies {
     implementation 'com.github.f4b6a3:tsid-creator:5.2.3'
 }
 
+def excludePatterns = [
+        '**/Ktb3CommunityApplication.class',
+        '**/config/**',
+        '**/common/**',
+        '**/mapper/**',
+        '**/repository/**',
+        '**/dto/**',
+        '**/exception/**',
+        '**/auth/infra/**',
+        '**/auth/security/**',
+        '**/auth/controller/TokenResponder.class'
+]
+
 tasks.named('test') {
     useJUnitPlatform()
     finalizedBy tasks.jacocoTestReport
@@ -63,45 +76,48 @@ tasks.withType(JavaCompile).configureEach {
     ]
 }
 
-
 jacoco {
     toolVersion = "0.8.12"
     reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
+
 jacocoTestReport {
+    dependsOn test
     reports {
         xml.required = false
         csv.required = false
         html.outputLocation = layout.buildDirectory.dir('jacocoHTML')
     }
-    dependsOn test
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: excludePatterns)
+        }))
+    }
+
     finalizedBy 'jacocoTestCoverageVerification'
 }
 
 jacocoTestCoverageVerification {
-    violationRules {
+    dependsOn jacocoTestReport
+    classDirectories.setFrom(jacocoTestReport.classDirectories)
 
+    violationRules {
         rule {
             enabled = true
             element = 'CLASS'
 
-            excludes = [
-                    'com.example.ktb3community.common.*',
-                    'com.example.ktb3community.*.exception.*',
-                    'com.example.ktb3community.*.dto.*',
-                    'com.example.ktb3community.*.mapper.*',
-                    'com.example.ktb3community.config.*',
-                    'com.example.ktb3community.Ktb3CommunityApplication'
-            ]
-
             limit {
                 counter = 'BRANCH'
                 value = 'COVEREDRATIO'
-                minimum = 0
+                minimum = 0.60
+            }
+
+            limit {
+                counter = 'LINE'
+                value = 'COVEREDRATIO'
+                minimum = 0.70
             }
         }
     }
 }
-
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {
@@ -93,7 +94,7 @@ jacocoTestCoverageVerification {
             ]
 
             limit {
-                counter = 'METHOD'
+                counter = 'BRANCH'
                 value = 'COVEREDRATIO'
                 minimum = 0
             }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.6'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.example'
@@ -38,8 +39,7 @@ dependencies {
 
     annotationProcessor 'org.projectlombok:lombok-mapstruct-binding:0.2.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
-    implementation 'com.mysql:mysql-connector-j:8.2.0'
-    runtimeOnly 'com.mysql:mysql-connector-j:8.2.0'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     implementation 'com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.12.0'
     implementation 'software.amazon.awssdk:s3:2.25.+'
     implementation 'org.springframework.boot:spring-boot-starter-security'
@@ -50,15 +50,46 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    finalizedBy tasks.jacocoTestReport
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs = [
-            '-Amapstruct.defaultComponentModel=spring'
+tasks.withType(JavaCompile).configureEach {
+    options.compilerArgs += [
+            '-Amapstruct.defaultComponentModel=spring',
+            '-parameters'
     ]
 }
 
-tasks.withType(JavaCompile) {
-    options.compilerArgs += ["-parameters"]
+
+jacoco {
+    toolVersion = "0.8.12"
+    reportsDirectory = layout.buildDirectory.dir('customJacocoReportDir')
 }
+jacocoTestReport {
+    reports {
+        xml.required = false
+        csv.required = false
+        html.outputLocation = layout.buildDirectory.dir('jacocoHTML')
+    }
+    dependsOn test
+    finalizedBy 'jacocoTestCoverageVerification'
+}
+
+jacocoTestCoverageVerification {
+    violationRules {
+
+        rule {
+            enabled = true
+            element = 'CLASS'
+
+            limit {
+                counter = 'METHOD'
+                value = 'COVEREDRATIO'
+                minimum = 0
+            }
+        }
+    }
+}
+
+
 

--- a/build.gradle
+++ b/build.gradle
@@ -48,6 +48,7 @@ dependencies {
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'com.h2database:h2'
+    implementation 'com.github.f4b6a3:tsid-creator:5.2.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/example/ktb3community/Ktb3CommunityApplication.java
+++ b/src/main/java/com/example/ktb3community/Ktb3CommunityApplication.java
@@ -2,9 +2,7 @@ package com.example.ktb3community;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
-@EnableJpaAuditing
 @SpringBootApplication
 public class Ktb3CommunityApplication {
 

--- a/src/main/java/com/example/ktb3community/auth/controller/TokenResponder.java
+++ b/src/main/java/com/example/ktb3community/auth/controller/TokenResponder.java
@@ -1,0 +1,28 @@
+package com.example.ktb3community.auth.controller;
+
+import com.example.ktb3community.auth.dto.AuthResponse;
+import com.example.ktb3community.auth.dto.Token;
+import com.example.ktb3community.common.response.ApiResult;
+import com.example.ktb3community.common.util.CookieUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenResponder {
+
+    public ResponseEntity<ApiResult<AuthResponse>> success(
+            Token token,
+            HttpServletResponse response,
+            HttpStatus status
+    ) {
+        CookieUtil.addRefreshTokenCookie(response, token.refreshToken());
+        AuthResponse authResponse = new AuthResponse(token.accessToken());
+
+        return ResponseEntity
+                .status(status)
+                .body(ApiResult.ok(authResponse));
+    }
+}
+

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -18,7 +18,7 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class RefreshToken implements Persistable<Long> {
+public class RefreshToken{
     @Id
     private Long id;
 
@@ -39,16 +39,6 @@ public class RefreshToken implements Persistable<Long> {
     @Transient
     private boolean isNew = true;
 
-    @Override
-    public boolean isNew() {
-        return isNew;
-    }
-
-    @PostLoad
-    @PostPersist
-    void markNotNew() {
-        this.isNew = false;
-    }
 
     public static RefreshToken createNew(Long id, User user, Instant expiresAt) {
         return RefreshToken.builder()

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -36,10 +36,6 @@ public class RefreshToken{
     @Column(nullable = false)
     private Long version;
 
-    @Transient
-    private boolean isNew = true;
-
-
     public static RefreshToken createNew(Long id, User user, Instant expiresAt) {
         return RefreshToken.builder()
                 .id(id)

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -2,9 +2,7 @@ package com.example.ktb3community.auth.domain;
 
 import com.example.ktb3community.user.domain.User;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Instant;
 import java.util.UUID;
@@ -18,6 +16,8 @@ import java.util.UUID;
 )
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class RefreshToken {
     @Id
     private String id;
@@ -32,19 +32,18 @@ public class RefreshToken {
     @Column(nullable = false)
     private boolean revoked;
 
-    private RefreshToken(String id, User user, Instant expiresAt, boolean revoked) {
-        this.id = id;
-        this.user = user;
-        this.expiresAt = expiresAt;
-        this.revoked = revoked;
-    }
-
     public static RefreshToken createNew(User user, Instant expiresAt) {
         String id = UUID.randomUUID().toString();
-        return new RefreshToken(id, user, expiresAt, false);
+        return RefreshToken.builder()
+                .id(id)
+                .user(user)
+                .expiresAt(expiresAt)
+                .revoked(false)
+                .build();
     }
 
     public void revoke() {
+        if(this.revoked) return;
         this.revoked = true;
     }
 

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -31,12 +31,17 @@ public class RefreshToken {
     @Column(nullable = false)
     private boolean revoked;
 
+    @Version
+    @Column(nullable = false)
+    private Long version;
+
     public static RefreshToken createNew(Long id, User user, Instant expiresAt) {
         return RefreshToken.builder()
                 .id(id)
                 .user(user)
                 .expiresAt(expiresAt)
                 .revoked(false)
+                .version(0L)
                 .build();
     }
 

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -5,7 +5,6 @@ import jakarta.persistence.*;
 import lombok.*;
 
 import java.time.Instant;
-import java.util.UUID;
 
 @Entity
 @Table(
@@ -20,7 +19,7 @@ import java.util.UUID;
 @Builder
 public class RefreshToken {
     @Id
-    private String id;
+    private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "user_id", nullable = false)
@@ -32,8 +31,7 @@ public class RefreshToken {
     @Column(nullable = false)
     private boolean revoked;
 
-    public static RefreshToken createNew(User user, Instant expiresAt) {
-        String id = UUID.randomUUID().toString();
+    public static RefreshToken createNew(Long id, User user, Instant expiresAt) {
         return RefreshToken.builder()
                 .id(id)
                 .user(user)

--- a/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
+++ b/src/main/java/com/example/ktb3community/auth/domain/RefreshToken.java
@@ -3,6 +3,7 @@ package com.example.ktb3community.auth.domain;
 import com.example.ktb3community.user.domain.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.springframework.data.domain.Persistable;
 
 import java.time.Instant;
 
@@ -17,7 +18,7 @@ import java.time.Instant;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @Builder
-public class RefreshToken {
+public class RefreshToken implements Persistable<Long> {
     @Id
     private Long id;
 
@@ -35,13 +36,26 @@ public class RefreshToken {
     @Column(nullable = false)
     private Long version;
 
+    @Transient
+    private boolean isNew = true;
+
+    @Override
+    public boolean isNew() {
+        return isNew;
+    }
+
+    @PostLoad
+    @PostPersist
+    void markNotNew() {
+        this.isNew = false;
+    }
+
     public static RefreshToken createNew(Long id, User user, Instant expiresAt) {
         return RefreshToken.builder()
                 .id(id)
                 .user(user)
                 .expiresAt(expiresAt)
                 .revoked(false)
-                .version(0L)
                 .build();
     }
 

--- a/src/main/java/com/example/ktb3community/auth/dto/Token.java
+++ b/src/main/java/com/example/ktb3community/auth/dto/Token.java
@@ -1,0 +1,6 @@
+package com.example.ktb3community.auth.dto;
+
+public record Token (
+        String accessToken,
+        String refreshToken
+){}

--- a/src/main/java/com/example/ktb3community/auth/infra/RefreshTokenIdGenerator.java
+++ b/src/main/java/com/example/ktb3community/auth/infra/RefreshTokenIdGenerator.java
@@ -1,0 +1,11 @@
+package com.example.ktb3community.auth.infra;
+
+import com.github.f4b6a3.tsid.TsidCreator;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RefreshTokenIdGenerator {
+    public long generate() {
+        return TsidCreator.getTsid().toLong();
+    }
+}

--- a/src/main/java/com/example/ktb3community/auth/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/example/ktb3community/auth/repository/RefreshTokenRepository.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface RefreshTokenRepository extends JpaRepository<RefreshToken, String> {
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update RefreshToken rt set rt.revoked = true " +
             "where rt.user = :user and rt.revoked = false")

--- a/src/main/java/com/example/ktb3community/auth/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/example/ktb3community/auth/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,36 @@
+package com.example.ktb3community.auth.security;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException {
+        ErrorResponseDto body = ErrorResponseDto.of(
+                ErrorCode.AUTH_FORBIDDEN.getCode(),
+                ErrorCode.AUTH_FORBIDDEN.getMessage()
+        );
+
+        response.setStatus(HttpStatus.FORBIDDEN.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/ktb3community/auth/security/CustomAuthenticationEntryPoint.java
+++ b/src/main/java/com/example/ktb3community/auth/security/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,36 @@
+package com.example.ktb3community.auth.security;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.ErrorResponseDto;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper;
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException {
+        ErrorResponseDto body = ErrorResponseDto.of(
+                ErrorCode.AUTH_UNAUTHORIZED.getCode(),
+                ErrorCode.AUTH_UNAUTHORIZED.getMessage()
+        );
+
+        response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        response.getWriter().write(objectMapper.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/example/ktb3community/auth/security/SecurityPaths.java
+++ b/src/main/java/com/example/ktb3community/auth/security/SecurityPaths.java
@@ -1,0 +1,29 @@
+package com.example.ktb3community.auth.security;
+
+public final class SecurityPaths {
+
+    private SecurityPaths() {}
+
+    public static final String[] PUBLIC_AUTH = {
+            "/auth/signup",
+            "/auth/login",
+            "/auth/refresh",
+            "/users/availability/**"
+    };
+
+    public static final String[] CSRF_IGNORED = {
+            "/auth/login",
+            "/auth/signup",
+            "/uploads/presigned-url",
+            "/users/availability/**",
+            "/v3/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+
+    public static final String[] PUBLIC_DOCS = {
+            "/v1/api-docs/**",
+            "/swagger-ui/**",
+            "/swagger-ui.html"
+    };
+}

--- a/src/main/java/com/example/ktb3community/auth/service/AuthService.java
+++ b/src/main/java/com/example/ktb3community/auth/service/AuthService.java
@@ -1,18 +1,16 @@
 package com.example.ktb3community.auth.service;
 
 import com.example.ktb3community.auth.domain.RefreshToken;
-import com.example.ktb3community.auth.dto.AuthResponse;
 import com.example.ktb3community.auth.dto.LoginRequest;
 import com.example.ktb3community.auth.dto.SignUpRequest;
+import com.example.ktb3community.auth.dto.Token;
 import com.example.ktb3community.common.Role;
 import com.example.ktb3community.common.error.ErrorCode;
-import com.example.ktb3community.common.util.CookieUtil;
 import com.example.ktb3community.exception.BusinessException;
 import com.example.ktb3community.jwt.JwtTokenProvider;
 import com.example.ktb3community.user.domain.User;
 import com.example.ktb3community.user.exception.UserNotFoundException;
 import com.example.ktb3community.user.repository.UserRepository;
-import jakarta.servlet.http.HttpServletResponse;
 import lombok.AllArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -28,7 +26,7 @@ public class AuthService {
     private final PasswordEncoder passwordEncoder;
 
     @Transactional
-    public AuthResponse signup(SignUpRequest signUpRequest, HttpServletResponse response) {
+    public Token signup(SignUpRequest signUpRequest) {
         String email = signUpRequest.email().trim().toLowerCase();
         String hashedPassword = passwordEncoder.encode(signUpRequest.password());
         if (userRepository.existsByEmail(email)) {
@@ -38,21 +36,22 @@ public class AuthService {
             throw new BusinessException(ErrorCode.NICKNAME_ALREADY_EXIST);
         }
         User saved = userRepository.save(User.createNew(email, hashedPassword, signUpRequest.nickname(), signUpRequest.profileImageUrl(), Role.ROLE_USER));
-        return issueTokens(saved, response);
+
+        return issueTokens(saved);
     }
 
     @Transactional
-    public AuthResponse login(LoginRequest loginRequest, HttpServletResponse response) {
+    public Token login(LoginRequest loginRequest) {
         String email = loginRequest.email().trim().toLowerCase();
         User user = userRepository.findByEmail(email).orElseThrow(UserNotFoundException::new);
         if (!passwordEncoder.matches(loginRequest.password(), user.getPasswordHash())) {
             throw new UserNotFoundException();
         }
-        return issueTokens(user, response);
+        return issueTokens(user);
     }
 
     @Transactional
-    public AuthResponse refresh(String oldRefreshToken, HttpServletResponse response) {
+    public Token refresh(String oldRefreshToken) {
         // JWT 검증 + revoked/expired 검사
         RefreshToken refreshToken = refreshTokenService.getValidTokenOrThrow(oldRefreshToken);
         User user = refreshToken.getUser();
@@ -60,30 +59,18 @@ public class AuthService {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String newRefreshToken = refreshTokenService.rotate(oldRefreshToken);
 
-        CookieUtil.addRefreshTokenCookie(
-                response,
-                newRefreshToken
-        );
-        return new AuthResponse(accessToken);
+        return new Token(accessToken, newRefreshToken);
     }
 
     @Transactional
-    public void logout(String refreshToken, HttpServletResponse response) {
-
+    public void logout(String refreshToken) {
         refreshTokenService.revoke(refreshToken);
-
-        CookieUtil.removeRefreshTokenCookie(response);
     }
 
-    private AuthResponse issueTokens(User user, HttpServletResponse response) {
+    private Token issueTokens(User user) {
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
         String refreshToken = refreshTokenService.createRefreshToken(user);
 
-        CookieUtil.addRefreshTokenCookie(
-                response,
-                refreshToken
-        );
-        return new AuthResponse(accessToken);
+        return new Token(accessToken, refreshToken);
     }
-
 }

--- a/src/main/java/com/example/ktb3community/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/ktb3community/auth/service/RefreshTokenService.java
@@ -1,6 +1,7 @@
 package com.example.ktb3community.auth.service;
 
 import com.example.ktb3community.auth.domain.RefreshToken;
+import com.example.ktb3community.auth.infra.RefreshTokenIdGenerator;
 import com.example.ktb3community.auth.repository.RefreshTokenRepository;
 import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
@@ -18,11 +19,14 @@ public class RefreshTokenService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final JwtTokenProvider jwtTokenProvider;
+    private final RefreshTokenIdGenerator refreshTokenIdGenerator;
 
     @Transactional
     public String createRefreshToken(User user) {
         Instant expiresAt = jwtTokenProvider.getRefreshExpiresAt();
-        RefreshToken refreshToken = RefreshToken.createNew(user, expiresAt);
+        long id = refreshTokenIdGenerator.generate();
+
+        RefreshToken refreshToken = RefreshToken.createNew(id, user, expiresAt);
         refreshTokenRepository.save(refreshToken);
 
         return jwtTokenProvider.createRefreshToken(

--- a/src/main/java/com/example/ktb3community/auth/service/RefreshTokenService.java
+++ b/src/main/java/com/example/ktb3community/auth/service/RefreshTokenService.java
@@ -7,9 +7,9 @@ import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
 import com.example.ktb3community.jwt.JwtTokenProvider;
 import com.example.ktb3community.user.domain.User;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.time.Instant;
 
@@ -37,7 +37,7 @@ public class RefreshTokenService {
 
     // JWT 서명/형식 검증
     public RefreshToken getValidTokenOrThrow(String refreshToken) {
-        String refreshTokenId = jwtTokenProvider.getRefreshTokenId(refreshToken);
+        Long refreshTokenId = jwtTokenProvider.getRefreshTokenId(refreshToken);
 
         RefreshToken token = refreshTokenRepository.findById(refreshTokenId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_REFRESH_TOKEN));
@@ -61,7 +61,7 @@ public class RefreshTokenService {
 
     @Transactional
     public void revoke(String refreshToken) {
-        String refreshTokenId = jwtTokenProvider.getRefreshTokenId(refreshToken);
+        Long refreshTokenId = jwtTokenProvider.getRefreshTokenId(refreshToken);
 
         RefreshToken token = refreshTokenRepository.findById(refreshTokenId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.NOT_EXIST_REFRESH_TOKEN));

--- a/src/main/java/com/example/ktb3community/comment/domain/Comment.java
+++ b/src/main/java/com/example/ktb3community/comment/domain/Comment.java
@@ -70,19 +70,14 @@ public class Comment extends BaseTimeEntity {
 
     @Override
     public boolean equals(Object o) {
-        if(this == o) return true;
-        if(o == null || getClass() != o.getClass()) return false;
+        if (this == o) return true;
+        if (!(o instanceof Comment comment)) return false;
 
-        Comment other = (Comment) o;
-        if(this.id == null || other.id == null ) return false;
-        return this.id.equals(other.id);
+        return id != null && id.equals(comment.getId());
     }
 
     @Override
     public int hashCode() {
-        if (id != null) {
-            return id.hashCode();
-        }
-        return System.identityHashCode(this);
+        return getClass().hashCode();
     }
 }

--- a/src/main/java/com/example/ktb3community/comment/domain/Comment.java
+++ b/src/main/java/com/example/ktb3community/comment/domain/Comment.java
@@ -6,8 +6,7 @@ import com.example.ktb3community.post.exception.PostNotFoundException;
 import com.example.ktb3community.user.domain.User;
 import com.example.ktb3community.user.exception.UserNotFoundException;
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Instant;
 
@@ -15,6 +14,8 @@ import java.time.Instant;
 @Table(name = "comments")
 @Getter
 @NoArgsConstructor(access = lombok.AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Comment extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -34,23 +35,13 @@ public class Comment extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
-    private Comment(Long id, Post post, User user, String content, Instant deletedAt) {
-        this.id = id;
-        this.post = post;
-        this.user = user;
-        this.content = content;
-        this.deletedAt = deletedAt;
-    }
-
     public static Comment createNew(Post post, User user, String content) {
-        return new Comment(null, post, user, content, null);
-    }
-
-    public static Comment rehydrate(Long id, Post post, User user, String content, Instant createdAt, Instant updatedAt, Instant deletedAt) {
-        Comment comment = new Comment(id, post, user, content, deletedAt);
-        comment.createdAt = createdAt;
-        comment.updatedAt = updatedAt;
-        return comment;
+        return Comment.builder()
+                .post(post)
+                .user(user)
+                .content(content)
+                .deletedAt(null)
+                .build();
     }
 
     public void updateContent(String content) {

--- a/src/main/java/com/example/ktb3community/comment/repository/InMemoryCommentRepositoryAdapter.java
+++ b/src/main/java/com/example/ktb3community/comment/repository/InMemoryCommentRepositoryAdapter.java
@@ -26,8 +26,13 @@ public class InMemoryCommentRepositoryAdapter implements CommentRepository {
     public Comment save(Comment comment) {
         if (comment.getId() == null) {
             long id = seq.getAndIncrement();
-            comment = Comment.rehydrate(id, comment.getPost(), comment.getUser(), comment.getContent(),
-                    comment.getCreatedAt(), comment.getUpdatedAt(), comment.getDeletedAt());
+            comment = Comment.builder()
+                    .id(id)
+                    .post(comment.getPost())
+                    .user(comment.getUser())
+                    .content(comment.getContent())
+                    .deletedAt(null)
+                    .build();
         }
         comments.put(comment.getId(), comment);
         return comment;

--- a/src/main/java/com/example/ktb3community/comment/service/CommentService.java
+++ b/src/main/java/com/example/ktb3community/comment/service/CommentService.java
@@ -89,11 +89,11 @@ public class CommentService {
     public void deleteComment(Long commentId, Long userId) {
         Comment comment =  commentRepository.findByIdOrThrow(commentId);
         User user = userRepository.findByIdOrThrow(userId);
-        Post post = postRepository.findByIdOrThrow(comment.getPostId());
         if(!comment.getUserId().equals(user.getId())) {
             throw new BusinessException(ErrorCode.AUTH_FORBIDDEN);
         }
         comment.delete(Instant.now());
+        Post post = postRepository.findByIdOrThrow(comment.getPostId());
         postCommentCounter.decreaseCommentCount(post.getId());
     }
 }

--- a/src/main/java/com/example/ktb3community/config/AuthConfig.java
+++ b/src/main/java/com/example/ktb3community/config/AuthConfig.java
@@ -1,0 +1,16 @@
+package com.example.ktb3community.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class AuthConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+

--- a/src/main/java/com/example/ktb3community/config/CorsConfig.java
+++ b/src/main/java/com/example/ktb3community/config/CorsConfig.java
@@ -1,0 +1,34 @@
+package com.example.ktb3community.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.CorsConfigurationSource;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+
+import java.util.List;
+
+@Configuration
+public class CorsConfig {
+
+    @Bean
+    public CorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration config = new CorsConfiguration();
+
+        config.setAllowedOrigins(List.of(
+                "http://localhost:3000",
+                "http://127.0.0.1:3000"
+        ));
+
+        config.setAllowedMethods(List.of("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
+        config.setAllowedHeaders(List.of("Authorization", "Content-Type", "X-XSRF-TOKEN"));
+        config.setExposedHeaders(List.of("Authorization"));
+        config.setAllowCredentials(true);
+        config.setMaxAge(3600L);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", config);
+
+        return source;
+    }
+}

--- a/src/main/java/com/example/ktb3community/config/JpaConfig.java
+++ b/src/main/java/com/example/ktb3community/config/JpaConfig.java
@@ -1,0 +1,9 @@
+package com.example.ktb3community.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+}

--- a/src/main/java/com/example/ktb3community/config/SecurityConfig.java
+++ b/src/main/java/com/example/ktb3community/config/SecurityConfig.java
@@ -22,6 +22,8 @@ import org.springframework.web.cors.CorsConfigurationSource;
 
 import java.nio.charset.StandardCharsets;
 
+import static com.example.ktb3community.auth.security.SecurityPaths.*;
+
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
@@ -30,30 +32,6 @@ public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService customUserDetailsService;
     private final CorsConfigurationSource corsConfigurationSource;
-
-    private static final String[] PUBLIC_AUTH_ENDPOINTS = {
-            "/auth/signup",
-            "/auth/login",
-            "/auth/refresh",
-            "/users/availability/**"
-    };
-
-    private static final String[] PUBLIC_DOCS_ENDPOINTS = {
-            "/v1/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html"
-    };
-
-    private static final String[] CSRF_IGNORED_ENDPOINTS = {
-            "/auth/login",
-            "/auth/signup",
-            "/uploads/presigned-url",
-            "/users/availability/**",
-            "/v3/api-docs/**",
-            "/swagger-ui/**",
-            "/swagger-ui.html"
-    };
-
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -68,7 +46,7 @@ public class SecurityConfig {
                 .csrf(csrf -> csrf
                         .csrfTokenRepository(csrfTokenRepository)
                         .csrfTokenRequestHandler(requestHandler)
-                        .ignoringRequestMatchers(CSRF_IGNORED_ENDPOINTS)
+                        .ignoringRequestMatchers(CSRF_IGNORED)
                 )
                 .exceptionHandling(ex -> ex
                         .authenticationEntryPoint((request, response, authException) -> {
@@ -99,8 +77,8 @@ public class SecurityConfig {
                         sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 )
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers(PUBLIC_AUTH_ENDPOINTS).permitAll()
-                        .requestMatchers(PUBLIC_DOCS_ENDPOINTS).permitAll()
+                        .requestMatchers(PUBLIC_AUTH).permitAll()
+                        .requestMatchers(PUBLIC_DOCS).permitAll()
                         .anyRequest().authenticated()
                 )
                 .userDetailsService(customUserDetailsService)

--- a/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
@@ -46,13 +46,6 @@ public class GlobalExceptionHandler {
                 .body(ErrorResponseDto.of(ErrorCode.INVALID_INPUT_VALUE.getCode(), ErrorCode.INVALID_INPUT_VALUE.getMessage()));
     }
 
-    @ExceptionHandler(BindException.class)
-    public ResponseEntity<ErrorResponseDto> handleBind(BindException ex) {
-        return ResponseEntity
-                .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                .body(ErrorResponseDto.of(ErrorCode.INVALID_INPUT_VALUE.getCode(), ErrorCode.INVALID_INPUT_VALUE.getMessage()));
-    }
-
     // === 400 요청 자체가 잘못 됨 ===
     @ExceptionHandler(HttpMessageNotReadableException.class)
     public ResponseEntity<ErrorResponseDto> handleHttpMessageNotReadable(HttpMessageNotReadableException ex) {

--- a/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
@@ -10,7 +10,6 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
-import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.MissingServletRequestParameterException;

--- a/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/example/ktb3community/exception/GlobalExceptionHandler.java
@@ -7,6 +7,7 @@ import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.validation.BindException;
@@ -125,6 +126,13 @@ public class GlobalExceptionHandler {
                 .status(HttpStatus.INTERNAL_SERVER_ERROR)
                 .body(ErrorResponseDto.of(ErrorCode.INTERNAL_SERVER_ERROR.getCode(),
                         ErrorCode.INTERNAL_SERVER_ERROR.getMessage()));
+    }
+
+    @ExceptionHandler(ObjectOptimisticLockingFailureException.class)
+    public ResponseEntity<ErrorResponseDto> handleOptimisticLock(ObjectOptimisticLockingFailureException ex) {
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ErrorResponseDto.of(ErrorCode.INVALID_REFRESH_TOKEN.getCode(),
+                        ErrorCode.INVALID_REFRESH_TOKEN.getMessage()));
     }
 
     private Throwable rootCause(Throwable t) {

--- a/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.example.ktb3community.jwt;
 
 import com.example.ktb3community.auth.security.CustomUserDetails;
 import com.example.ktb3community.auth.security.CustomUserDetailsService;
+import com.example.ktb3community.auth.security.SecurityPaths;
 import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
 import jakarta.servlet.FilterChain;
@@ -13,10 +14,11 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.WebAuthenticationDetailsSource;
+import org.springframework.util.AntPathMatcher;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
-import java.util.Set;
+import java.util.Arrays;
 
 @RequiredArgsConstructor
 @Getter
@@ -24,23 +26,14 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
-
-    private static final Set<String> PUBLIC_PATHS = Set.of(
-            "/auth/login",
-            "/auth/signup",
-            "/auth/refresh",
-            "/uploads/presigned-url"
-    );
+    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getRequestURI();
 
-        if (PUBLIC_PATHS.contains(path)) {
-            return true;
-        }
-
-        return path.startsWith("/users/availability/");
+        return Arrays.stream(SecurityPaths.PUBLIC_AUTH)
+                .anyMatch(pattern -> pathMatcher.match(pattern, path));
     }
 
     // 모든 요청마다 이 메서드가 호출되고, 여기서 JWT 검증과 인증 처리를 한 뒤 다음 필터로 넘어감

--- a/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
@@ -26,13 +26,18 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final CustomUserDetailsService userDetailsService;
-    private static final AntPathMatcher pathMatcher = new AntPathMatcher();
+    private final AntPathMatcher pathMatcher = new AntPathMatcher();
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
         String path = request.getServletPath();
-        return Arrays.stream(SecurityPaths.PUBLIC_AUTH)
-                .anyMatch(pattern -> pathMatcher.match(pattern, path));
+
+        for (String pattern : SecurityPaths.PUBLIC_AUTH) {
+            if (pathMatcher.match(pattern, path)) {
+                return true;
+            }
+        }
+        return false;
     }
 
     // 모든 요청마다 이 메서드가 호출되고, 여기서 JWT 검증과 인증 처리를 한 뒤 다음 필터로 넘어감

--- a/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/example/ktb3community/jwt/JwtAuthenticationFilter.java
@@ -30,8 +30,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     @Override
     protected boolean shouldNotFilter(HttpServletRequest request) {
-        String path = request.getRequestURI();
-
+        String path = request.getServletPath();
         return Arrays.stream(SecurityPaths.PUBLIC_AUTH)
                 .anyMatch(pattern -> pathMatcher.match(pattern, path));
     }

--- a/src/main/java/com/example/ktb3community/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/ktb3community/jwt/JwtTokenProvider.java
@@ -44,12 +44,12 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    public String createRefreshToken(String refreshTokenId, Long userId) {
+    public String createRefreshToken(Long refreshTokenId, Long userId) {
         Instant now = Instant.now();
         Instant exp = now.plus(refreshExpDays, ChronoUnit.DAYS);
 
         return Jwts.builder()
-                .setId(refreshTokenId)
+                .setId(refreshTokenId.toString())
                 .setSubject(userId.toString())
                 .setIssuedAt(Date.from(now))
                 .setExpiration(Date.from(exp))

--- a/src/main/java/com/example/ktb3community/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/example/ktb3community/jwt/JwtTokenProvider.java
@@ -74,9 +74,9 @@ public class JwtTokenProvider {
         return Instant.now().plus(refreshExpDays, ChronoUnit.DAYS);
     }
 
-    public String getRefreshTokenId(String refreshToken) {
+    public Long getRefreshTokenId(String refreshToken) {
         Claims claims = parseClaims(refreshToken, ErrorCode.INVALID_REFRESH_TOKEN);
-        return claims.getId();
+        return Long.valueOf(claims.getId());
     }
 
     public Long getUserIdFromAccessToken(String accessToken) {

--- a/src/main/java/com/example/ktb3community/post/domain/Like.java
+++ b/src/main/java/com/example/ktb3community/post/domain/Like.java
@@ -12,15 +12,15 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Instant;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 @Table(name = "likes", uniqueConstraints = {
         @UniqueConstraint(name = "uq_like_post_user", columnNames = {"post_id", "user_id"})
 })
@@ -40,15 +40,13 @@ public class Like extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
-    private Like(Long id, Post post, User user, Instant deletedAt) {
-        this.id = id;
-        this.post = post;
-        this.user = user;
-        this.deletedAt = deletedAt;
-    }
 
     public static Like createNew(Post post, User user) {
-        return new Like(null, post, user,null);
+        return Like.builder()
+                .post(post)
+                .user(user)
+                .deletedAt(null)
+                .build();
     }
 
     public boolean isDeleted() {

--- a/src/main/java/com/example/ktb3community/post/domain/Post.java
+++ b/src/main/java/com/example/ktb3community/post/domain/Post.java
@@ -37,7 +37,7 @@ public class Post extends BaseTimeEntity {
     private String title;
 
     @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "LONGTEXT", nullable = false)
     private String content;
 
     @Column(name = "post_image_url")

--- a/src/main/java/com/example/ktb3community/post/domain/Post.java
+++ b/src/main/java/com/example/ktb3community/post/domain/Post.java
@@ -69,7 +69,7 @@ public class Post extends BaseTimeEntity {
     }
 
     public void updatePost(String title, String content, String postImageUrl) {
-        if ( title != null && !title.isBlank() ){ this.title = title; }
+        if ( title != null && !title.isBlank() ){ this.title = title.trim(); }
         if ( content != null && !content.isBlank() ) { this.content = content; }
         this.postImageUrl = postImageUrl;
     }
@@ -109,19 +109,14 @@ public class Post extends BaseTimeEntity {
 
     @Override
     public boolean equals(Object o) {
-        if(this == o) return true;
-        if(o == null || getClass() != o.getClass()) return false;
+        if (this == o) return true;
+        if (!(o instanceof Post post)) return false;
 
-        Post other = (Post) o;
-        if(this.id == null || other.id == null ) return false;
-        return this.id.equals(other.id);
+        return id != null && id.equals(post.getId());
     }
 
     @Override
     public int hashCode() {
-        if (id != null) {
-            return id.hashCode();
-        }
-        return System.identityHashCode(this);
+        return getClass().hashCode();
     }
 }

--- a/src/main/java/com/example/ktb3community/post/domain/Post.java
+++ b/src/main/java/com/example/ktb3community/post/domain/Post.java
@@ -14,9 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Instant;
 
@@ -24,6 +22,8 @@ import java.time.Instant;
 @Table(name = "posts")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class Post extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -55,27 +55,17 @@ public class Post extends BaseTimeEntity {
     @Column(name = "deleted_at")
     private Instant deletedAt;
 
-    private Post(Long id, User user, String title, String content, String postImageUrl, long like, long view, long cmt,
-                 Instant deletedAt) {
-        this.id = id;
-        this.user = user;
-        this.title = title.trim();
-        this.content = content;
-        this.postImageUrl = postImageUrl;
-        this.likeCount = like;
-        this.viewCount = view;
-        this.commentCount = cmt;
-        this.deletedAt = deletedAt;
-    }
-
     public static Post createNew(User user, String title, String content, String postImageUrl) {
-        return new Post(null, user, title, content, postImageUrl, 0, 0, 0, null);
-    }
-    public static Post rehydrate(Long id, User user, String title, String content, String postImageUrl, long like, long view, long cmt, Instant createdAt, Instant updatedAt, Instant deletedAt) {
-        Post post =  new Post(id, user, title, content, postImageUrl, like, view, cmt, deletedAt);
-        post.createdAt = createdAt;
-        post.updatedAt = updatedAt;
-        return post;
+        return Post.builder()
+                .user(user)
+                .title(title.trim())
+                .content(content)
+                .postImageUrl(postImageUrl)
+                .likeCount(0)
+                .viewCount(0)
+                .commentCount(0)
+                .deletedAt(null)
+                .build();
     }
 
     public void updatePost(String title, String content, String postImageUrl) {

--- a/src/main/java/com/example/ktb3community/post/repository/InMemoryPostRepositoryAdapter.java
+++ b/src/main/java/com/example/ktb3community/post/repository/InMemoryPostRepositoryAdapter.java
@@ -25,9 +25,17 @@ public class InMemoryPostRepositoryAdapter implements PostRepository {
     public Post save(Post post) {
         if (post.getId() == null) {
             long id = seq.getAndIncrement();
-            post = Post.rehydrate(id, post.getUser(), post.getTitle(), post.getContent(), post.getPostImageUrl(),
-                    post.getLikeCount(), post.getViewCount(), post.getCommentCount(),
-                    post.getCreatedAt(), post.getUpdatedAt(), post.getDeletedAt());
+            post = Post.builder()
+                    .id(id)
+                    .user(post.getUser())
+                    .title(post.getTitle())
+                    .content(post.getContent())
+                    .postImageUrl(post.getPostImageUrl())
+                    .likeCount(post.getLikeCount())
+                    .viewCount(post.getViewCount())
+                    .commentCount(post.getCommentCount())
+                    .deletedAt(null)
+                    .build();
         }
         posts.put(post.getId(), post);
         return post;

--- a/src/main/java/com/example/ktb3community/user/domain/User.java
+++ b/src/main/java/com/example/ktb3community/user/domain/User.java
@@ -6,9 +6,7 @@ import com.example.ktb3community.common.domain.BaseTimeEntity;
 import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
 import jakarta.persistence.*;
-import lombok.AccessLevel;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.Instant;
 
@@ -16,6 +14,8 @@ import java.time.Instant;
 @Table(name = "users")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
 public class User extends BaseTimeEntity {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -39,28 +39,15 @@ public class User extends BaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Role role;
 
-
-    private User(Long id, String email, String passwordHash, String nickname, String profileImageUrl, Instant deletedAt, Role role) {
-        this.id = id;
-        this.email = email.trim().toLowerCase();
-        this.passwordHash = passwordHash;
-        this.nickname = nickname.trim();
-        this.profileImageUrl = profileImageUrl.trim();
-        this.deletedAt = deletedAt;
-        this.role = role;
-    }
-
     public static User createNew(String email, String passwordHash,
                                  String nickname, String profileImageUrl, Role role) {
-        return new User(null, email, passwordHash, nickname, profileImageUrl, null, role);
-    }
-
-    public static User rehydrate(Long id, String email, String passwordHash,
-                                 String nickname, String profileImageUrl, Instant createdAt, Instant updatedAt, Instant deletedAt, Role role) {
-        User user = new User(id, email, passwordHash, nickname, profileImageUrl, deletedAt, role);
-        user.createdAt = createdAt;
-        user.updatedAt = updatedAt;
-        return user;
+        return User.builder()
+                .email(email.toLowerCase().trim())
+                .passwordHash(passwordHash)
+                .nickname(nickname.trim())
+                .profileImageUrl(profileImageUrl.trim())
+                .role(role)
+                .build();
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/com/example/ktb3community/user/domain/User.java
+++ b/src/main/java/com/example/ktb3community/user/domain/User.java
@@ -45,7 +45,7 @@ public class User extends BaseTimeEntity {
         this.email = email.trim().toLowerCase();
         this.passwordHash = passwordHash;
         this.nickname = nickname.trim();
-        this.profileImageUrl = profileImageUrl;
+        this.profileImageUrl = profileImageUrl.trim();
         this.deletedAt = deletedAt;
         this.role = role;
     }

--- a/src/main/java/com/example/ktb3community/user/domain/User.java
+++ b/src/main/java/com/example/ktb3community/user/domain/User.java
@@ -77,19 +77,14 @@ public class User extends BaseTimeEntity {
 
     @Override
     public boolean equals(Object o) {
-        if(this == o) return true;
-        if(o == null || getClass() != o.getClass()) return false;
+        if (this == o) return true;
+        if (!(o instanceof User user)) return false;
 
-        User other = (User) o;
-        if(this.id == null || other.id == null ) return false;
-        return this.id.equals(other.id);
+        return id != null && id.equals(user.getId());
     }
 
     @Override
     public int hashCode() {
-        if (id != null) {
-            return id.hashCode();
-        }
-        return System.identityHashCode(this);
+        return getClass().hashCode();
     }
 }

--- a/src/main/java/com/example/ktb3community/user/domain/User.java
+++ b/src/main/java/com/example/ktb3community/user/domain/User.java
@@ -84,6 +84,7 @@ public class User extends BaseTimeEntity {
     }
 
     public void updatePasswordHash(String passwordHash) {
+        if (passwordHash == null || passwordHash.isBlank()) { throw new BusinessException(ErrorCode.INVALID_INPUT_VALUE); }
         this.passwordHash = passwordHash;
     }
 

--- a/src/main/java/com/example/ktb3community/user/repository/InMemoryUserRepositoryAdapter.java
+++ b/src/main/java/com/example/ktb3community/user/repository/InMemoryUserRepositoryAdapter.java
@@ -26,8 +26,15 @@ public class InMemoryUserRepositoryAdapter implements UserRepository {
         User userToSave = user;
         if (userToSave.getId() == null) {
             long id = seq.getAndIncrement();
-            userToSave = User.rehydrate(id, user.getEmail(), user.getPasswordHash(), user.getNickname(),
-                    user.getProfileImageUrl(), user.getCreatedAt(), user.getUpdatedAt(), user.getDeletedAt(), Role.ROLE_USER);
+            userToSave = User.builder()
+                    .id(id)
+                    .email(user.getEmail())
+                    .passwordHash(user.getPasswordHash())
+                    .nickname(user.getNickname())
+                    .profileImageUrl(user.getProfileImageUrl())
+                    .role(user.getRole())
+                    .deletedAt(null)
+                    .build();
             emailToUserId.put(userToSave.getEmail(), id);
             nicknameToUserId.put(userToSave.getNickname(), id);
         } else {

--- a/src/main/java/com/example/ktb3community/user/repository/InMemoryUserRepositoryAdapter.java
+++ b/src/main/java/com/example/ktb3community/user/repository/InMemoryUserRepositoryAdapter.java
@@ -1,7 +1,6 @@
 package com.example.ktb3community.user.repository;
 
 
-import com.example.ktb3community.common.Role;
 import com.example.ktb3community.user.domain.User;
 import com.example.ktb3community.user.exception.UserNotFoundException;
 import org.springframework.stereotype.Repository;

--- a/src/test/java/com/example/ktb3community/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/ktb3community/GlobalExceptionHandlerTest.java
@@ -5,6 +5,7 @@ import com.example.ktb3community.exception.CustomException;
 import com.example.ktb3community.exception.GlobalExceptionHandler;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -43,6 +44,26 @@ class GlobalExceptionHandlerTest {
             throw new CustomException(ErrorCode.USER_NOT_FOUND);
         }
 
+        @PostMapping("/validation")
+        void throwValidation(@Valid @RequestBody TestDto dto) {
+            // @NotNull 위반 유도
+        }
+
+        @GetMapping("/type-mismatch")
+        void throwTypeMismatch(@RequestParam Long id) {
+            // String -> Long 변환 실패 유도
+        }
+
+        @GetMapping("/constraint-violation")
+        void throwConstraintViolation(@NotBlank @RequestParam String value) {
+            // 빈 문자열 전달 시 ConstraintViolationException 유도
+        }
+
+        @GetMapping("/missing-param")
+        void throwMissingParam(@RequestParam String name) {
+            // 필수 파라미터 누락 유도
+        }
+
         @GetMapping("/authentication")
         void throwAuthentication() {
             throw new AuthenticationException("Auth failed") {};
@@ -65,6 +86,7 @@ class GlobalExceptionHandlerTest {
 
         @PostMapping("/bind")
         void throwBind(@Valid @ModelAttribute BindDto dto) {
+            // ModelAttribute 바인딩 검증 실패 유도
         }
 
         @GetMapping("/runtime")
@@ -75,6 +97,11 @@ class GlobalExceptionHandlerTest {
         @GetMapping("/no-handler")
         void throwNoHandler() throws NoHandlerFoundException {
             throw new NoHandlerFoundException("GET", "/test/no-handler", null);
+        }
+
+        public static class TestDto {
+            @NotNull
+            public String content;
         }
 
         public static class BindDto {

--- a/src/test/java/com/example/ktb3community/GlobalExceptionHandlerTest.java
+++ b/src/test/java/com/example/ktb3community/GlobalExceptionHandlerTest.java
@@ -1,0 +1,197 @@
+package com.example.ktb3community;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.CustomException;
+import com.example.ktb3community.exception.GlobalExceptionHandler;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.orm.ObjectOptimisticLockingFailureException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.NoHandlerFoundException;
+import org.springframework.validation.annotation.Validated;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GlobalExceptionHandlerTest.TestController.class)
+@AutoConfigureMockMvc(addFilters = false)
+@Import({GlobalExceptionHandler.class, GlobalExceptionHandlerTest.TestController.class})
+class GlobalExceptionHandlerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @RestController
+    @RequestMapping("/test")
+    @Validated
+    public static class TestController {
+
+        @GetMapping("/custom")
+        void throwCustom() {
+            throw new CustomException(ErrorCode.USER_NOT_FOUND);
+        }
+
+        @GetMapping("/authentication")
+        void throwAuthentication() {
+            throw new AuthenticationException("Auth failed") {};
+        }
+
+        @GetMapping("/access-denied")
+        void throwAccessDenied() {
+            throw new AccessDeniedException("Access denied");
+        }
+
+        @GetMapping("/data-integrity")
+        void throwDataIntegrity() {
+            throw new DataIntegrityViolationException("Constraint violation");
+        }
+
+        @GetMapping("/optimistic-lock")
+        void throwOptimisticLock() {
+            throw new ObjectOptimisticLockingFailureException(Object.class, "1");
+        }
+
+        @PostMapping("/bind")
+        void throwBind(@Valid @ModelAttribute BindDto dto) {
+        }
+
+        @GetMapping("/runtime")
+        void throwRuntime() {
+            throw new RuntimeException("Unexpected error");
+        }
+
+        @GetMapping("/no-handler")
+        void throwNoHandler() throws NoHandlerFoundException {
+            throw new NoHandlerFoundException("GET", "/test/no-handler", null);
+        }
+
+        public static class BindDto {
+            @NotBlank
+            public String content;
+        }
+    }
+
+    @Test
+    @DisplayName("[CustomException] 커스텀 예외 발생 시 지정된 상태 코드와 에러 코드를 반환한다")
+    void handleCustomException() throws Exception {
+        mockMvc.perform(get("/test/custom"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("[422] @Valid 검증 실패 시 UNPROCESSABLE_ENTITY 반환")
+    void handleMethodArgumentNotValid() throws Exception {
+        mockMvc.perform(post("/test/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{}"))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[400] 파라미터 타입 불일치 시 BAD_REQUEST 반환")
+    void handleMethodArgumentTypeMismatch() throws Exception {
+        mockMvc.perform(get("/test/type-mismatch")
+                        .param("id", "invalid-long"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PARAMETER_TYPE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[422] 제약 조건 위반(ConstraintViolationException) 시 UNPROCESSABLE_ENTITY 반환")
+    void handleConstraintViolation() throws Exception {
+        mockMvc.perform(get("/test/constraint-violation")
+                        .param("value", "   "))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[400] 필수 파라미터 누락 시 BAD_REQUEST 반환")
+    void handleMissingServletRequestParameter() throws Exception {
+        mockMvc.perform(get("/test/missing-param"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_PARAMETER.getCode()));
+    }
+
+    @Test
+    @DisplayName("[400] JSON 형식이 잘못된 경우(Body 읽기 실패) BAD_REQUEST 반환")
+    void handleHttpMessageNotReadable() throws Exception {
+        String malformedJson = "{ \"field\": \"value\"";
+
+        mockMvc.perform(post("/test/validation")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(malformedJson))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST_BODY.getCode()));
+    }
+
+    @Test
+    @DisplayName("[405] 지원하지 않는 HTTP 메서드 요청 시 METHOD_NOT_ALLOWED 반환")
+    void handleHttpRequestMethodNotSupported() throws Exception {
+        mockMvc.perform(delete("/test/custom"))
+                .andExpect(status().isMethodNotAllowed())
+                .andExpect(jsonPath("$.code").value(ErrorCode.METHOD_NOT_ALLOWED.getCode()));
+    }
+
+    @Test
+    @DisplayName("[401] 인증 예외(AuthenticationException) 발생 시 UNAUTHORIZED 반환")
+    void handleAuthentication() throws Exception {
+        mockMvc.perform(get("/test/authentication"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.AUTH_UNAUTHORIZED.getCode()));
+    }
+
+    @Test
+    @DisplayName("[403] 인가 예외(AccessDeniedException) 발생 시 FORBIDDEN 반환")
+    void handleAccessDenied() throws Exception {
+        mockMvc.perform(get("/test/access-denied"))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.AUTH_FORBIDDEN.getCode()));
+    }
+
+    @Test
+    @DisplayName("[409] 데이터 무결성 위반 시 CONFLICT 반환")
+    void handleDataIntegrity() throws Exception {
+        mockMvc.perform(get("/test/data-integrity"))
+                .andExpect(status().isConflict())
+                .andExpect(jsonPath("$.code").value(ErrorCode.CONFLICT.getCode()));
+    }
+
+    @Test
+    @DisplayName("[401] 낙관적 락 충돌 시 UNAUTHORIZED 반환")
+    void handleOptimisticLock() throws Exception {
+        mockMvc.perform(get("/test/optimistic-lock"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()));
+    }
+
+    @Test
+    @DisplayName("[404] 핸들러를 찾을 수 없을 때(NoHandlerFoundException) NOT_FOUND 반환")
+    void handleNoHandlerFound() throws Exception {
+        mockMvc.perform(get("/test/no-handler"))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("[500] 알 수 없는 예외 발생 시 INTERNAL_SERVER_ERROR 반환")
+    void handleUnknown() throws Exception {
+        mockMvc.perform(get("/test/runtime"))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INTERNAL_SERVER_ERROR.getCode()));
+    }
+}

--- a/src/test/java/com/example/ktb3community/TestEntityFactory.java
+++ b/src/test/java/com/example/ktb3community/TestEntityFactory.java
@@ -9,11 +9,6 @@ import com.example.ktb3community.user.domain.User;
 
 import java.time.Instant;
 
-import static com.example.ktb3community.TestFixtures.COMMENT_ID;
-import static com.example.ktb3community.TestFixtures.POST_ID;
-import static com.example.ktb3community.TestFixtures.TOKEN_ID;
-import static com.example.ktb3community.TestFixtures.USER_ID;
-
 public final class TestEntityFactory {
 
     private static final String DEFAULT_EMAIL = "user@test.com";
@@ -34,7 +29,7 @@ public final class TestEntityFactory {
 
     public static User.UserBuilder user() {
         return User.builder()
-                .id(USER_ID)
+                .id(null)
                 .email(DEFAULT_EMAIL)
                 .passwordHash(DEFAULT_PASSWORD_HASH)
                 .nickname(DEFAULT_NICKNAME)
@@ -48,7 +43,7 @@ public final class TestEntityFactory {
 
     public static Post.PostBuilder post(User user) {
         return Post.builder()
-                .id(POST_ID)
+                .id(null)
                 .user(user)
                 .title(DEFAULT_POST_TITLE)
                 .content(DEFAULT_POST_CONTENT)
@@ -61,7 +56,7 @@ public final class TestEntityFactory {
 
     public static Comment.CommentBuilder comment(Post post, User user) {
         return Comment.builder()
-                .id(COMMENT_ID)
+                .id(null)
                 .post(post)
                 .user(user)
                 .content(DEFAULT_COMMENT_CONTENT)
@@ -77,7 +72,7 @@ public final class TestEntityFactory {
 
     public static RefreshToken.RefreshTokenBuilder refreshToken(User user) {
         return RefreshToken.builder()
-                .id(TOKEN_ID)
+                .id(null)
                 .user(user)
                 .expiresAt(DEFAULT_REFRESH_EXPIRES_AT)
                 .revoked(false)

--- a/src/test/java/com/example/ktb3community/TestEntityFactory.java
+++ b/src/test/java/com/example/ktb3community/TestEntityFactory.java
@@ -1,0 +1,86 @@
+package com.example.ktb3community;
+
+import com.example.ktb3community.auth.domain.RefreshToken;
+import com.example.ktb3community.comment.domain.Comment;
+import com.example.ktb3community.common.Role;
+import com.example.ktb3community.post.domain.Like;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.user.domain.User;
+
+import java.time.Instant;
+
+import static com.example.ktb3community.TestFixtures.COMMENT_ID;
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.TOKEN_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+
+public final class TestEntityFactory {
+
+    private static final String DEFAULT_EMAIL = "user@test.com";
+    private static final String DEFAULT_PASSWORD_HASH = "password-hash";
+    private static final String DEFAULT_NICKNAME = "tester";
+    private static final String DEFAULT_PROFILE_IMAGE = "http://image.test/profile.jpg";
+
+    private static final String DEFAULT_POST_TITLE = "Post Title";
+    private static final String DEFAULT_POST_CONTENT = "Post Content";
+    private static final String DEFAULT_POST_IMAGE_URL = "http://image.test/post.jpg";
+
+    private static final String DEFAULT_COMMENT_CONTENT = "Comment Content";
+
+    private static final Instant DEFAULT_REFRESH_EXPIRES_AT = Instant.parse("2099-01-01T00:00:00Z");
+
+    private TestEntityFactory() {
+    }
+
+    public static User.UserBuilder user() {
+        return User.builder()
+                .id(USER_ID)
+                .email(DEFAULT_EMAIL)
+                .passwordHash(DEFAULT_PASSWORD_HASH)
+                .nickname(DEFAULT_NICKNAME)
+                .profileImageUrl(DEFAULT_PROFILE_IMAGE)
+                .role(Role.ROLE_USER);
+    }
+
+    public static Post.PostBuilder post() {
+        return post(user().build());
+    }
+
+    public static Post.PostBuilder post(User user) {
+        return Post.builder()
+                .id(POST_ID)
+                .user(user)
+                .title(DEFAULT_POST_TITLE)
+                .content(DEFAULT_POST_CONTENT)
+                .postImageUrl(DEFAULT_POST_IMAGE_URL)
+                .likeCount(0)
+                .viewCount(0)
+                .commentCount(0)
+                .deletedAt(null);
+    }
+
+    public static Comment.CommentBuilder comment(Post post, User user) {
+        return Comment.builder()
+                .id(COMMENT_ID)
+                .post(post)
+                .user(user)
+                .content(DEFAULT_COMMENT_CONTENT)
+                .deletedAt(null);
+    }
+
+    public static Like.LikeBuilder like(Post post, User user) {
+        return Like.builder()
+                .post(post)
+                .user(user)
+                .deletedAt(null);
+    }
+
+    public static RefreshToken.RefreshTokenBuilder refreshToken(User user) {
+        return RefreshToken.builder()
+                .id(TOKEN_ID)
+                .user(user)
+                .expiresAt(DEFAULT_REFRESH_EXPIRES_AT)
+                .revoked(false)
+                .version(0L);
+    }
+}

--- a/src/test/java/com/example/ktb3community/TestFixtures.java
+++ b/src/test/java/com/example/ktb3community/TestFixtures.java
@@ -5,6 +5,7 @@ public class TestFixtures {
 
     public static final Long USER_ID = 1L;
     public static final Long POST_ID = 100L;
+    public static final Long COMMENT_ID = 50L;
     private static final String REFRESH_TOKEN_ID = "test-refresh-token-id";
 
 

--- a/src/test/java/com/example/ktb3community/TestFixtures.java
+++ b/src/test/java/com/example/ktb3community/TestFixtures.java
@@ -7,7 +7,6 @@ public class TestFixtures {
     public static final Long POST_ID = 100L;
     public static final Long COMMENT_ID = 50L;
     public static final Long TOKEN_ID = 100L;
-    private static final String JWT = "test-refresh-token-id";
 
     public static final String ACCESS_TOKEN = "access.token";
     public static final String REFRESH_TOKEN = "refresh.token";

--- a/src/test/java/com/example/ktb3community/TestFixtures.java
+++ b/src/test/java/com/example/ktb3community/TestFixtures.java
@@ -6,7 +6,11 @@ public class TestFixtures {
     public static final Long USER_ID = 1L;
     public static final Long POST_ID = 100L;
     public static final Long COMMENT_ID = 50L;
-    private static final String REFRESH_TOKEN_ID = "test-refresh-token-id";
+    public static final Long TOKEN_ID = 100L;
+    private static final String JWT = "test-refresh-token-id";
+
+    public static final String ACCESS_TOKEN = "access.token";
+    public static final String REFRESH_TOKEN = "refresh.token";
 
 
 }

--- a/src/test/java/com/example/ktb3community/TestFixtures.java
+++ b/src/test/java/com/example/ktb3community/TestFixtures.java
@@ -1,0 +1,11 @@
+package com.example.ktb3community;
+
+
+public class TestFixtures {
+
+    public static final Long USER_ID = 1L;
+    public static final Long POST_ID = 100L;
+    private static final String REFRESH_TOKEN_ID = "test-refresh-token-id";
+
+
+}

--- a/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
+++ b/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
@@ -138,4 +138,13 @@ class AuthControllerTest {
 
         verify(authService).logout(REFRESH_TOKEN);
     }
+
+    @Test
+    @DisplayName("[401] 로그아웃 시 리프레시 토큰이 없으면 예외 발생")
+    void logout_no_cookie_throws() throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()));
+    }
 }

--- a/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
+++ b/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
@@ -55,7 +55,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[201] 회원가입 성공")
-    void signup_201() throws Exception {
+    void signup_201_success() throws Exception {
         SignUpRequest request = new SignUpRequest("test@email.com", "Password1234!", "nickname", "img");
         Token token = new Token(ACCESS_TOKEN, REFRESH_TOKEN);
 
@@ -78,7 +78,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[200] 로그인 성공")
-    void login_200() throws Exception {
+    void login_200_success() throws Exception {
         LoginRequest request = new LoginRequest("test@email.com", "Password1234!");
         Token token = new Token(ACCESS_TOKEN, REFRESH_TOKEN);
 
@@ -100,7 +100,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[200] 토큰 갱신 성공 (쿠키 필수)")
-    void refresh_200() throws Exception {
+    void refresh_200_withCookie() throws Exception {
         Token newToken = new Token("new.access", "new.refresh");
         AuthResponse authResponse = new AuthResponse("new.access");
         ResponseEntity<ApiResult<AuthResponse>> responseEntity = ResponseEntity
@@ -119,7 +119,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[401] 리프레시 토큰 쿠키가 없으면 예외 발생")
-    void refresh_no_cookie_throws() throws Exception {
+    void refresh_401_missingCookie() throws Exception {
         mockMvc.perform(post("/auth/refresh")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized())
@@ -128,7 +128,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[204] 로그아웃 성공")
-    void logout_204() throws Exception {
+    void logout_204_success() throws Exception {
         mockMvc.perform(post("/auth/logout")
                         .cookie(new Cookie("refresh_token", REFRESH_TOKEN))
                         .with(csrf()))
@@ -141,7 +141,7 @@ class AuthControllerTest {
 
     @Test
     @DisplayName("[401] 로그아웃 시 리프레시 토큰이 없으면 예외 발생")
-    void logout_no_cookie_throws() throws Exception {
+    void logout_401_missingCookie() throws Exception {
         mockMvc.perform(post("/auth/logout")
                         .with(csrf()))
                 .andExpect(status().isUnauthorized())

--- a/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
+++ b/src/test/java/com/example/ktb3community/auth/AuthControllerTest.java
@@ -1,0 +1,141 @@
+package com.example.ktb3community.auth;
+
+import com.example.ktb3community.auth.controller.AuthController;
+import com.example.ktb3community.auth.controller.TokenResponder;
+import com.example.ktb3community.auth.dto.AuthResponse;
+import com.example.ktb3community.auth.dto.LoginRequest;
+import com.example.ktb3community.auth.dto.SignUpRequest;
+import com.example.ktb3community.auth.dto.Token;
+import com.example.ktb3community.auth.service.AuthService;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.common.response.ApiResult;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.example.ktb3community.TestFixtures.ACCESS_TOKEN;
+import static com.example.ktb3community.TestFixtures.REFRESH_TOKEN;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(AuthController.class)
+class AuthControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean AuthService authService;
+    @MockitoBean
+    TokenResponder tokenResponder;
+
+    @BeforeEach
+    void setUp() {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken("user", null, null));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("[201] 회원가입 성공")
+    void signup_201() throws Exception {
+        SignUpRequest request = new SignUpRequest("test@email.com", "Password1234!", "nickname", "img");
+        Token token = new Token(ACCESS_TOKEN, REFRESH_TOKEN);
+
+        AuthResponse authResponse = new AuthResponse(ACCESS_TOKEN);
+        ResponseEntity<ApiResult<AuthResponse>> responseEntity = ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResult.ok(authResponse));
+
+        given(authService.signup(any(SignUpRequest.class))).willReturn(token);
+        given(tokenResponder.success(eq(token), any(HttpServletResponse.class), eq(HttpStatus.CREATED)))
+                .willReturn(responseEntity);
+
+        mockMvc.perform(post("/auth/signup")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.accessToken").value(ACCESS_TOKEN));
+    }
+
+    @Test
+    @DisplayName("[200] 로그인 성공")
+    void login_200() throws Exception {
+        LoginRequest request = new LoginRequest("test@email.com", "Password1234!");
+        Token token = new Token(ACCESS_TOKEN, REFRESH_TOKEN);
+
+        AuthResponse authResponse = new AuthResponse(ACCESS_TOKEN);
+        ResponseEntity<ApiResult<AuthResponse>> responseEntity = ResponseEntity
+                .ok(ApiResult.ok(authResponse));
+
+        given(authService.login(any(LoginRequest.class))).willReturn(token);
+        given(tokenResponder.success(eq(token), any(HttpServletResponse.class), eq(HttpStatus.OK)))
+                .willReturn(responseEntity);
+
+        mockMvc.perform(post("/auth/login")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value(ACCESS_TOKEN));
+    }
+
+    @Test
+    @DisplayName("[200] 토큰 갱신 성공 (쿠키 필수)")
+    void refresh_200() throws Exception {
+        Token newToken = new Token("new.access", "new.refresh");
+        AuthResponse authResponse = new AuthResponse("new.access");
+        ResponseEntity<ApiResult<AuthResponse>> responseEntity = ResponseEntity
+                .ok(ApiResult.ok(authResponse));
+
+        given(authService.refresh(REFRESH_TOKEN)).willReturn(newToken);
+        given(tokenResponder.success(eq(newToken), any(HttpServletResponse.class), eq(HttpStatus.OK)))
+                .willReturn(responseEntity);
+
+        mockMvc.perform(post("/auth/refresh")
+                        .cookie(new Cookie("refresh_token", REFRESH_TOKEN))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.accessToken").value("new.access"));
+    }
+
+    @Test
+    @DisplayName("[401] 리프레시 토큰 쿠키가 없으면 예외 발생")
+    void refresh_no_cookie_throws() throws Exception {
+        mockMvc.perform(post("/auth/refresh")
+                        .with(csrf()))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REFRESH_TOKEN.getCode()));
+    }
+
+    @Test
+    @DisplayName("[204] 로그아웃 성공")
+    void logout_204() throws Exception {
+        mockMvc.perform(post("/auth/logout")
+                        .cookie(new Cookie("refresh_token", REFRESH_TOKEN))
+                        .with(csrf()))
+                .andExpect(status().isNoContent())
+                .andExpect(header().exists("Set-Cookie"))
+                .andExpect(cookie().maxAge("refresh_token", 0));
+
+        verify(authService).logout(REFRESH_TOKEN);
+    }
+}

--- a/src/test/java/com/example/ktb3community/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/ktb3community/auth/AuthServiceTest.java
@@ -45,8 +45,7 @@ class AuthServiceTest {
     @InjectMocks
     AuthService authService;
 
-    // 헬퍼: 더미 유저 생성
-    private User newUSer(String email, String passwordHash) {
+    private User newUser(String email, String passwordHash) {
         User user = User.createNew(email, passwordHash, "nickname", "img", Role.ROLE_USER);
         ReflectionTestUtils.setField(user, "id", USER_ID);
         return user;
@@ -118,7 +117,7 @@ class AuthServiceTest {
     @DisplayName("login: 이메일과 비밀번호가 일치하면 토큰을 발급한다")
     void login_success() {
         LoginRequest request = new LoginRequest("test@email.com", "password");
-        User user = newUSer("test@email.com", "encodedPassword");
+        User user = newUser("test@email.com", "encodedPassword");
 
         given(userRepository.findByEmail("test@email.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("password", "encodedPassword")).willReturn(true);
@@ -146,7 +145,7 @@ class AuthServiceTest {
     @DisplayName("login: 비밀번호가 일치하지 않으면 UserNotFoundException 발생")
     void login_wrongPassword_throws() {
         LoginRequest request = new LoginRequest("test@email.com", "wrongPw");
-        User user = newUSer("test@email.com", "encodedPassword");
+        User user = newUser("test@email.com", "encodedPassword");
 
         given(userRepository.findByEmail("test@email.com")).willReturn(Optional.of(user));
         given(passwordEncoder.matches("wrongPw", "encodedPassword")).willReturn(false);
@@ -161,7 +160,7 @@ class AuthServiceTest {
         String oldRefreshToken = "old.refresh.token";
         String newRefreshToken = "new.refresh.token";
         String newAccessToken = "new.access.token";
-        User user = newUSer("email", "pw");
+        User user = newUser("email", "pw");
 
         RefreshToken validToken = RefreshToken.createNew(100L, user, null);
         given(refreshTokenService.getValidTokenOrThrow(oldRefreshToken)).willReturn(validToken);

--- a/src/test/java/com/example/ktb3community/auth/AuthServiceTest.java
+++ b/src/test/java/com/example/ktb3community/auth/AuthServiceTest.java
@@ -1,0 +1,190 @@
+package com.example.ktb3community.auth;
+
+import com.example.ktb3community.auth.domain.RefreshToken;
+import com.example.ktb3community.auth.dto.LoginRequest;
+import com.example.ktb3community.auth.dto.SignUpRequest;
+import com.example.ktb3community.auth.dto.Token;
+import com.example.ktb3community.auth.service.AuthService;
+import com.example.ktb3community.auth.service.RefreshTokenService;
+import com.example.ktb3community.common.Role;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.jwt.JwtTokenProvider;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.exception.UserNotFoundException;
+import com.example.ktb3community.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock
+    RefreshTokenService refreshTokenService;
+    @Mock PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    AuthService authService;
+
+    // 헬퍼: 더미 유저 생성
+    private User newUSer(String email, String passwordHash) {
+        User user = User.createNew(email, passwordHash, "nickname", "img", Role.ROLE_USER);
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        return user;
+    }
+
+    @Test
+    @DisplayName("signup: 이메일/닉네임 중복이 없으면 회원을 저장하고 토큰을 발급한다")
+    void signup_success() {
+        SignUpRequest request = new SignUpRequest("test@email.com", "password", "nickname", "img");
+        String encodedPassword = "encodedPassword";
+
+        given(passwordEncoder.encode("password")).willReturn(encodedPassword);
+        given(userRepository.existsByEmail("test@email.com")).willReturn(false);
+        given(userRepository.existsByNickname("nickname")).willReturn(false);
+
+        given(userRepository.save(any(User.class))).willAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "id", USER_ID);
+            return user;
+        });
+
+        given(jwtTokenProvider.createAccessToken(USER_ID)).willReturn("access.token");
+        given(refreshTokenService.createRefreshToken(any(User.class))).willReturn("refresh.token");
+
+        Token token = authService.signup(request);
+
+        assertThat(token.accessToken()).isEqualTo("access.token");
+        assertThat(token.refreshToken()).isEqualTo("refresh.token");
+
+        ArgumentCaptor<User> captor = ArgumentCaptor.forClass(User.class);
+        verify(userRepository).save(captor.capture());
+        User savedUser = captor.getValue();
+
+        assertThat(savedUser.getEmail()).isEqualTo("test@email.com");
+        assertThat(savedUser.getPasswordHash()).isEqualTo(encodedPassword);
+    }
+
+    @Test
+    @DisplayName("signup: 이미 존재하는 이메일이면 EMAIL_ALREADY_EXIST 예외 발생")
+    void signup_emailDuplicate_throws() {
+        SignUpRequest request = new SignUpRequest("test@email.com", "pw", "nick", "img");
+        given(userRepository.existsByEmail("test@email.com")).willReturn(true);
+
+        Throwable thrown = catchThrowable(() -> authService.signup(request));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.EMAIL_ALREADY_EXIST);
+    }
+
+    @Test
+    @DisplayName("signup: 이미 존재하는 닉네임이면 NICKNAME_ALREADY_EXIST 예외 발생")
+    void signup_nicknameDuplicate_throws() {
+        // Given
+        SignUpRequest request = new SignUpRequest("test@email.com", "pw", "nick", "img");
+        given(userRepository.existsByEmail("test@email.com")).willReturn(false);
+        given(userRepository.existsByNickname("nick")).willReturn(true);
+
+        Throwable thrown = catchThrowable(() -> authService.signup(request));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.NICKNAME_ALREADY_EXIST);
+    }
+
+    @Test
+    @DisplayName("login: 이메일과 비밀번호가 일치하면 토큰을 발급한다")
+    void login_success() {
+        LoginRequest request = new LoginRequest("test@email.com", "password");
+        User user = newUSer("test@email.com", "encodedPassword");
+
+        given(userRepository.findByEmail("test@email.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("password", "encodedPassword")).willReturn(true);
+
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("access.token");
+        given(refreshTokenService.createRefreshToken(user)).willReturn("refresh.token");
+
+        Token token = authService.login(request);
+
+        assertThat(token.accessToken()).isEqualTo("access.token");
+        assertThat(token.refreshToken()).isEqualTo("refresh.token");
+    }
+
+    @Test
+    @DisplayName("login: 존재하지 않는 이메일이면 UserNotFoundException 발생")
+    void login_emailNotFound_throws() {
+        LoginRequest request = new LoginRequest("unknown@email.com", "pw");
+        given(userRepository.findByEmail("unknown@email.com")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("login: 비밀번호가 일치하지 않으면 UserNotFoundException 발생")
+    void login_wrongPassword_throws() {
+        LoginRequest request = new LoginRequest("test@email.com", "wrongPw");
+        User user = newUSer("test@email.com", "encodedPassword");
+
+        given(userRepository.findByEmail("test@email.com")).willReturn(Optional.of(user));
+        given(passwordEncoder.matches("wrongPw", "encodedPassword")).willReturn(false);
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("refresh: 유효한 리프레시 토큰으로 액세스 토큰 재발급 및 리프레시 토큰 교체(Rotate)")
+    void refresh_success() {
+        String oldRefreshToken = "old.refresh.token";
+        String newRefreshToken = "new.refresh.token";
+        String newAccessToken = "new.access.token";
+        User user = newUSer("email", "pw");
+
+        RefreshToken validToken = RefreshToken.createNew(100L, user, null);
+        given(refreshTokenService.getValidTokenOrThrow(oldRefreshToken)).willReturn(validToken);
+
+        given(jwtTokenProvider.createAccessToken(user.getId())).willReturn(newAccessToken);
+        given(refreshTokenService.rotate(oldRefreshToken)).willReturn(newRefreshToken);
+
+        Token token = authService.refresh(oldRefreshToken);
+
+        assertThat(token.accessToken()).isEqualTo(newAccessToken);
+        assertThat(token.refreshToken()).isEqualTo(newRefreshToken);
+
+        verify(refreshTokenService).getValidTokenOrThrow(oldRefreshToken);
+        verify(refreshTokenService).rotate(oldRefreshToken);
+    }
+
+    @Test
+    @DisplayName("logout: 리프레시 토큰을 폐기한다")
+    void logout_success() {
+        String refreshToken = "target.token";
+
+        authService.logout(refreshToken);
+
+        verify(refreshTokenService).revoke(refreshToken);
+    }
+}

--- a/src/test/java/com/example/ktb3community/auth/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/ktb3community/auth/RefreshTokenServiceTest.java
@@ -130,7 +130,7 @@ class RefreshTokenServiceTest {
         String oldJwt = "old.jwt";
         Long oldTokenId = 100L;
         Long newTokenId = 200L;
-        User user = user().build();
+        User user = user().id(USER_ID).build();
 
         RefreshToken oldToken = refreshToken(user).id(oldTokenId).expiresAt(Instant.now().plusSeconds(3600)).build();
 
@@ -139,7 +139,7 @@ class RefreshTokenServiceTest {
 
         given(refreshTokenIdGenerator.generate()).willReturn(newTokenId);
         given(jwtTokenProvider.getRefreshExpiresAt()).willReturn(Instant.now().plusSeconds(3600));
-        given(jwtTokenProvider.createRefreshToken(newTokenId, 1L)).willReturn("new.jwt");
+        given(jwtTokenProvider.createRefreshToken(newTokenId, USER_ID)).willReturn("new.jwt");
 
         String newJwt = refreshTokenService.rotate(oldJwt);
 

--- a/src/test/java/com/example/ktb3community/auth/RefreshTokenServiceTest.java
+++ b/src/test/java/com/example/ktb3community/auth/RefreshTokenServiceTest.java
@@ -1,0 +1,204 @@
+package com.example.ktb3community.auth;
+
+import com.example.ktb3community.auth.domain.RefreshToken;
+import com.example.ktb3community.auth.infra.RefreshTokenIdGenerator;
+import com.example.ktb3community.auth.repository.RefreshTokenRepository;
+import com.example.ktb3community.auth.service.RefreshTokenService;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.jwt.JwtTokenProvider;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.example.ktb3community.TestFixtures.TOKEN_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.config.Elements.JWT;
+
+@ExtendWith(MockitoExtension.class)
+class RefreshTokenServiceTest {
+
+    @Mock RefreshTokenRepository refreshTokenRepository;
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock RefreshTokenIdGenerator refreshTokenIdGenerator;
+
+    @InjectMocks
+    RefreshTokenService refreshTokenService;
+
+    private User newUser() {
+        User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        return user;
+    }
+
+    private RefreshToken newRefreshToken(Long id, User user, Instant expiresAt) {
+        return RefreshToken.createNew(id, user, expiresAt);
+    }
+
+    @Test
+    @DisplayName("createRefreshToken: ID 생성, DB 저장 후 JWT 문자열을 반환한다")
+    void createRefreshToken_success() {
+        User user = newUser();
+        Instant expiresAt = Instant.now().plusSeconds(3600);
+
+        given(jwtTokenProvider.getRefreshExpiresAt()).willReturn(expiresAt);
+        given(refreshTokenIdGenerator.generate()).willReturn(TOKEN_ID);
+        given(jwtTokenProvider.createRefreshToken(TOKEN_ID, USER_ID)).willReturn(JWT);
+
+        String resultJwt = refreshTokenService.createRefreshToken(user);
+
+        assertThat(resultJwt).isEqualTo(JWT);
+
+        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository).save(captor.capture());
+
+        RefreshToken savedToken = captor.getValue();
+        assertThat(savedToken.getId()).isEqualTo(TOKEN_ID);
+        assertThat(savedToken.getUser()).isEqualTo(user);
+        assertThat(savedToken.getExpiresAt()).isEqualTo(expiresAt);
+        assertThat(savedToken.isRevoked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("getValidToken: 유효한 토큰이면 객체를 반환한다")
+    void getValidToken_success() {
+        Long tokenId = 100L;
+        RefreshToken token = newRefreshToken(tokenId, newUser(), Instant.now().plusSeconds(3600));
+
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(tokenId);
+        given(refreshTokenRepository.findById(tokenId)).willReturn(Optional.of(token));
+
+        RefreshToken result = refreshTokenService.getValidTokenOrThrow(JWT);
+
+        assertThat(result).isEqualTo(token);
+    }
+
+    @Test
+    @DisplayName("getValidToken: DB에 토큰이 없으면 NOT_EXIST_REFRESH_TOKEN 예외 발생")
+    void getValidToken_notFound_throws() {
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(TOKEN_ID);
+        given(refreshTokenRepository.findById(TOKEN_ID)).willReturn(Optional.empty());
+
+        Throwable thrown = catchThrowable(() -> refreshTokenService.getValidTokenOrThrow(JWT));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_EXIST_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("getValidToken: 이미 만료된 토큰이면 REFRESH_TOKEN_EXPIRED 예외 발생")
+    void getValidToken_expiredTime_throws() {
+        RefreshToken token = newRefreshToken(TOKEN_ID, newUser(), Instant.now().minusSeconds(10));
+
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(TOKEN_ID);
+        given(refreshTokenRepository.findById(TOKEN_ID)).willReturn(Optional.of(token));
+
+        Throwable thrown = catchThrowable(() -> refreshTokenService.getValidTokenOrThrow(JWT));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("getValidToken: 이미 폐기된 토큰이면 REFRESH_TOKEN_EXPIRED 예외 발생")
+    void getValidToken_revoked_throws() {
+        RefreshToken token = newRefreshToken(TOKEN_ID, newUser(), Instant.now().plusSeconds(3600));
+        token.revoke();
+
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(TOKEN_ID);
+        given(refreshTokenRepository.findById(TOKEN_ID)).willReturn(Optional.of(token));
+
+        Throwable thrown = catchThrowable(() -> refreshTokenService.getValidTokenOrThrow(JWT));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+
+    @Test
+    @DisplayName("rotate: 기존 토큰을 폐기하고 새로운 토큰을 발급한다 (Rotation)")
+    void rotate_success() {
+        String oldJwt = "old.jwt";
+        Long oldTokenId = 100L;
+        Long newTokenId = 200L;
+        User user = newUser();
+
+        RefreshToken oldToken = newRefreshToken(oldTokenId, user, Instant.now().plusSeconds(3600));
+
+        given(jwtTokenProvider.getRefreshTokenId(oldJwt)).willReturn(oldTokenId);
+        given(refreshTokenRepository.findById(oldTokenId)).willReturn(Optional.of(oldToken));
+
+        given(refreshTokenIdGenerator.generate()).willReturn(newTokenId);
+        given(jwtTokenProvider.getRefreshExpiresAt()).willReturn(Instant.now().plusSeconds(3600));
+        given(jwtTokenProvider.createRefreshToken(newTokenId, 1L)).willReturn("new.jwt");
+
+        String newJwt = refreshTokenService.rotate(oldJwt);
+
+        assertThat(newJwt).isEqualTo("new.jwt");
+
+        assertThat(oldToken.isRevoked()).isTrue();
+
+        ArgumentCaptor<RefreshToken> captor = ArgumentCaptor.forClass(RefreshToken.class);
+        verify(refreshTokenRepository).save(captor.capture());
+
+        RefreshToken newToken = captor.getValue();
+        assertThat(newToken.getId()).isEqualTo(newTokenId);
+        assertThat(newToken.getUser()).isEqualTo(user);
+        assertThat(newToken.isRevoked()).isFalse();
+    }
+
+    @Test
+    @DisplayName("revoke: 토큰을 명시적으로 폐기한다")
+    void revoke_success() {
+        RefreshToken token = newRefreshToken(TOKEN_ID, newUser(), Instant.now().plusSeconds(3600));
+
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(TOKEN_ID);
+        given(refreshTokenRepository.findById(TOKEN_ID)).willReturn(Optional.of(token));
+
+        refreshTokenService.revoke(JWT);
+
+        assertThat(token.isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("revoke: 존재하지 않는 토큰이면 예외가 발생한다")
+    void revoke_notFound_throws() {
+        given(jwtTokenProvider.getRefreshTokenId(JWT)).willReturn(TOKEN_ID);
+        given(refreshTokenRepository.findById(TOKEN_ID)).willReturn(Optional.empty());
+
+        Throwable thrown = catchThrowable(() -> refreshTokenService.revoke(JWT));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.NOT_EXIST_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("revokeAllByUser: 유저의 모든 토큰을 폐기 요청한다")
+    void revokeAllByUser_success() {
+        User user = newUser();
+
+        refreshTokenService.revokeAllByUser(user);
+
+        verify(refreshTokenRepository).revokeAllByUser(user);
+    }
+}

--- a/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
+++ b/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
@@ -27,8 +27,6 @@ class RefreshTokenTest {
         assertThat(token.getExpiresAt()).isEqualTo(expiresAt);
 
         assertThat(token.isRevoked()).isFalse();
-
-        assertThat(token.getVersion()).isZero();
     }
 
     @Test

--- a/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
+++ b/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
@@ -4,26 +4,20 @@ import com.example.ktb3community.auth.domain.RefreshToken;
 import com.example.ktb3community.user.domain.User;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 
 import static com.example.ktb3community.TestFixtures.TOKEN_ID;
 import static com.example.ktb3community.TestFixtures.USER_ID;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class RefreshTokenTest {
 
-    private User newUser() {
-        User user = User.builder().build();
-        ReflectionTestUtils.setField(user, "id", USER_ID);
-        return user;
-    }
-
     @Test
     @DisplayName("createNew: 토큰 생성 시 version은 0L로 초기화되고, revoked는 false다")
     void createNew_success() {
-        User user = newUser();
+        User user = user().id(USER_ID).build();
         Instant expiresAt = Instant.now().plusSeconds(3600);
 
         RefreshToken token = RefreshToken.createNew(TOKEN_ID, user, expiresAt);
@@ -40,7 +34,7 @@ class RefreshTokenTest {
     @Test
     @DisplayName("revoke: 토큰을 폐기하면 revoked 상태가 true가 된다")
     void revoke_success() {
-        RefreshToken token = RefreshToken.createNew(TOKEN_ID, newUser(), Instant.now());
+        RefreshToken token = RefreshToken.createNew(TOKEN_ID, user().build(), Instant.now());
         assertThat(token.isRevoked()).isFalse();
 
         token.revoke();
@@ -51,7 +45,7 @@ class RefreshTokenTest {
     @Test
     @DisplayName("revoke: 이미 폐기된 토큰을 다시 폐기해도 상태는 유지된다")
     void revoke_idempotent() {
-        RefreshToken token = RefreshToken.createNew(TOKEN_ID, newUser(), Instant.now());
+        RefreshToken token = RefreshToken.createNew(TOKEN_ID, user().build(), Instant.now());
         token.revoke();
 
         token.revoke();

--- a/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
+++ b/src/test/java/com/example/ktb3community/auth/RefreshTokenTest.java
@@ -1,0 +1,87 @@
+package com.example.ktb3community.auth;
+
+import com.example.ktb3community.auth.domain.RefreshToken;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static com.example.ktb3community.TestFixtures.TOKEN_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RefreshTokenTest {
+
+    private User newUser() {
+        User user = User.builder().build();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        return user;
+    }
+
+    @Test
+    @DisplayName("createNew: 토큰 생성 시 version은 0L로 초기화되고, revoked는 false다")
+    void createNew_success() {
+        User user = newUser();
+        Instant expiresAt = Instant.now().plusSeconds(3600);
+
+        RefreshToken token = RefreshToken.createNew(TOKEN_ID, user, expiresAt);
+
+        assertThat(token.getId()).isEqualTo(TOKEN_ID);
+        assertThat(token.getUser()).isEqualTo(user);
+        assertThat(token.getExpiresAt()).isEqualTo(expiresAt);
+
+        assertThat(token.isRevoked()).isFalse();
+
+        assertThat(token.getVersion()).isZero();
+    }
+
+    @Test
+    @DisplayName("revoke: 토큰을 폐기하면 revoked 상태가 true가 된다")
+    void revoke_success() {
+        RefreshToken token = RefreshToken.createNew(TOKEN_ID, newUser(), Instant.now());
+        assertThat(token.isRevoked()).isFalse();
+
+        token.revoke();
+
+        assertThat(token.isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("revoke: 이미 폐기된 토큰을 다시 폐기해도 상태는 유지된다")
+    void revoke_idempotent() {
+        RefreshToken token = RefreshToken.createNew(TOKEN_ID, newUser(), Instant.now());
+        token.revoke();
+
+        token.revoke();
+
+        assertThat(token.isRevoked()).isTrue();
+    }
+
+    @Test
+    @DisplayName("isExpired: 만료 시간이 현재 시간보다 이전이면 true를 반환한다")
+    void isExpired_true() {
+        Instant now = Instant.now();
+        Instant past = now.minusSeconds(10);
+
+        RefreshToken token = RefreshToken.builder()
+                .expiresAt(past)
+                .build();
+
+        assertThat(token.isExpired(now)).isTrue();
+    }
+
+    @Test
+    @DisplayName("isExpired: 만료 시간이 현재 시간보다 이후이면 false를 반환한다")
+    void isExpired_false() {
+        Instant now = Instant.now();
+        Instant future = now.plusSeconds(10);
+
+        RefreshToken token = RefreshToken.builder()
+                .expiresAt(future)
+                .build();
+
+        assertThat(token.isExpired(now)).isFalse();
+    }
+}

--- a/src/test/java/com/example/ktb3community/comment/CommentControllerTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentControllerTest.java
@@ -1,0 +1,139 @@
+package com.example.ktb3community.comment;
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.comment.controller.CommentController;
+import com.example.ktb3community.comment.dto.CommentResponse;
+import com.example.ktb3community.comment.dto.CreateCommentRequest;
+import com.example.ktb3community.comment.service.CommentService;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.common.pagination.PageResponse;
+import com.example.ktb3community.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static com.example.ktb3community.TestFixtures.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CommentController.class)
+class CommentControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    CommentService commentService;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = User.builder()
+                .id(USER_ID)
+                .email("user@test.com")
+                .role(com.example.ktb3community.common.Role.ROLE_USER)
+                .build();
+
+        CustomUserDetails principal = CustomUserDetails.from(mockUser);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("[201] 댓글 생성 성공")
+    void createComment_201() throws Exception {
+        CreateCommentRequest request = new CreateCommentRequest("Nice Post!");
+        CommentResponse response = new CommentResponse(COMMENT_ID, "Nice Post!", null, null);
+
+        given(commentService.createComment(eq(POST_ID), eq(USER_ID), any(CreateCommentRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/posts/{postId}/comments", POST_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.commentId").value(COMMENT_ID))
+                .andExpect(jsonPath("$.data.content").value("Nice Post!"));
+    }
+
+    @Test
+    @DisplayName("[422] 내용이 없는 댓글 생성 시 유효성 검사 실패")
+    void createComment_422_invalid() throws Exception {
+        CreateCommentRequest invalidRequest = new CreateCommentRequest("");
+
+        mockMvc.perform(post("/posts/{postId}/comments", POST_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+                        .with(csrf()))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 댓글 목록 조회 성공")
+    void getComments_200() throws Exception {
+        PageResponse<CommentResponse> response = new PageResponse<>(Collections.emptyList(), 1, 10, 0);
+
+        given(commentService.getCommentList(POST_ID, 1)).willReturn(response);
+
+        mockMvc.perform(get("/posts/{postId}/comments", POST_ID)
+                        .param("page", "1")
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[400] 페이지 번호가 1 미만이면 예외 발생")
+    void getComments_400_invalidPage() throws Exception {
+        mockMvc.perform(get("/posts/{postId}/comments", POST_ID)
+                        .param("page", "0")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PAGE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 댓글 수정 성공")
+    void updateComment_200() throws Exception {
+        CreateCommentRequest request = new CreateCommentRequest("Updated Content");
+        CommentResponse response = new CommentResponse(COMMENT_ID, "Updated Content", null, null);
+
+        given(commentService.updateComment(eq(COMMENT_ID), eq(USER_ID), any(CreateCommentRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/comments/{commentId}", COMMENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content").value("Updated Content"));
+    }
+
+    @Test
+    @DisplayName("[204] 댓글 삭제 성공")
+    void deleteComment_204() throws Exception {
+        mockMvc.perform(delete("/comments/{commentId}", COMMENT_ID)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(commentService).deleteComment(COMMENT_ID, USER_ID);
+    }
+}

--- a/src/test/java/com/example/ktb3community/comment/CommentControllerTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentControllerTest.java
@@ -58,7 +58,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("[201] 댓글 생성 성공")
-    void createComment_201() throws Exception {
+    void createComment_201_success() throws Exception {
         CreateCommentRequest request = new CreateCommentRequest("Nice Post!");
         CommentResponse response = new CommentResponse(COMMENT_ID, "Nice Post!", null, null);
 
@@ -76,7 +76,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("[422] 내용이 없는 댓글 생성 시 유효성 검사 실패")
-    void createComment_422_invalid() throws Exception {
+    void createComment_422_invalidContent() throws Exception {
         CreateCommentRequest invalidRequest = new CreateCommentRequest("");
 
         mockMvc.perform(post("/posts/{postId}/comments", POST_ID)
@@ -89,7 +89,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("[200] 댓글 목록 조회 성공")
-    void getComments_200() throws Exception {
+    void getComments_200_success() throws Exception {
         PageResponse<CommentResponse> response = new PageResponse<>(Collections.emptyList(), 1, 10, 0);
 
         given(commentService.getCommentList(POST_ID, 1)).willReturn(response);
@@ -112,7 +112,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("[200] 댓글 수정 성공")
-    void updateComment_200() throws Exception {
+    void updateComment_200_success() throws Exception {
         CreateCommentRequest request = new CreateCommentRequest("Updated Content");
         CommentResponse response = new CommentResponse(COMMENT_ID, "Updated Content", null, null);
 
@@ -129,7 +129,7 @@ class CommentControllerTest {
 
     @Test
     @DisplayName("[204] 댓글 삭제 성공")
-    void deleteComment_204() throws Exception {
+    void deleteComment_204_success() throws Exception {
         mockMvc.perform(delete("/comments/{commentId}", COMMENT_ID)
                         .with(csrf()))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
@@ -1,0 +1,250 @@
+package com.example.ktb3community.comment;
+
+import com.example.ktb3community.comment.domain.Comment;
+import com.example.ktb3community.comment.dto.CommentResponse;
+import com.example.ktb3community.comment.dto.CreateCommentRequest;
+import com.example.ktb3community.comment.mapper.CommentMapper;
+import com.example.ktb3community.comment.repository.CommentRepository;
+import com.example.ktb3community.comment.service.CommentService;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.common.pagination.PageResponse;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.post.repository.PostRepository;
+import com.example.ktb3community.post.service.PostCommentCounter;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.exception.UserNotFoundException;
+import com.example.ktb3community.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+
+@ExtendWith(MockitoExtension.class)
+class CommentServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock CommentRepository commentRepository;
+    @Mock PostRepository postRepository;
+    @Mock PostCommentCounter postCommentCounter;
+    @Mock CommentMapper commentMapper;
+
+    @InjectMocks
+    CommentService commentService;
+
+    private User newUser(Long id) {
+        User user = User.builder().nickname("nick").build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Post newPost(Long id) {
+        Post post = Post.builder().build();
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+
+    private Comment newComment(Long id, Post post, User user, String content) {
+        Comment comment = Comment.createNew(post, user, content);
+        ReflectionTestUtils.setField(comment, "id", id);
+        return comment;
+    }
+
+    @Test
+    @DisplayName("createComment: 댓글 저장 후 카운트를 증가시키고 응답을 반환한다")
+    void createComment_success() {
+        Long postId = 10L;
+        Long userId = 1L;
+        CreateCommentRequest request = new CreateCommentRequest("New Comment");
+
+        User user = newUser(userId);
+        Post post = newPost(postId);
+        Comment savedComment = newComment(100L, post, user, "New Comment");
+
+        given(userRepository.findByIdOrThrow(userId)).willReturn(user);
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+
+        given(commentRepository.save(any(Comment.class))).willReturn(savedComment);
+
+        CommentResponse expectedResponse = new CommentResponse(100L, "New Comment", null, null);
+        given(commentMapper.toCommentResponse(savedComment, user)).willReturn(expectedResponse);
+
+        CommentResponse response = commentService.createComment(postId, userId, request);
+
+        assertThat(response).isEqualTo(expectedResponse);
+
+        verify(postCommentCounter).increaseCommentCount(postId);
+
+        ArgumentCaptor<Comment> captor = ArgumentCaptor.forClass(Comment.class);
+        verify(commentRepository).save(captor.capture());
+        assertThat(captor.getValue().getContent()).isEqualTo("New Comment");
+    }
+
+    @Test
+    @DisplayName("getCommentList: 댓글 목록과 작성자 정보를 매핑하여 반환한다")
+    void getCommentList_success() {
+        Long postId = 10L;
+        Post post = newPost(postId);
+        User user1 = newUser(1L);
+        User user2 = newUser(2L);
+
+        Comment c1 = newComment(100L, post, user1, "Content1");
+        Comment c2 = newComment(101L, post, user2, "Content2");
+
+        Page<Comment> commentPage = new PageImpl<>(List.of(c1, c2));
+
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+        given(commentRepository.findByPost(any(Post.class), any(PageRequest.class))).willReturn(commentPage);
+
+        given(userRepository.findAllByIdIn(Set.of(1L, 2L))).willReturn(List.of(user1, user2));
+
+        given(commentMapper.toCommentResponse(any(), any())).willAnswer(invocation -> {
+            Comment c = invocation.getArgument(0);
+            return new CommentResponse(c.getId(), c.getContent(), null, null);
+        });
+
+        PageResponse<CommentResponse> response = commentService.getCommentList(postId, 1);
+
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0).content()).isEqualTo("Content1");
+        assertThat(response.content().get(1).content()).isEqualTo("Content2");
+    }
+
+    @Test
+    @DisplayName("getCommentList: 작성자 정보가 없으면 UserNotFoundException 발생")
+    void getCommentList_userNotFound_throws() {
+        Long postId = 10L;
+        Post post = newPost(postId);
+        User user1 = newUser(1L);
+        Comment c1 = newComment(100L, post, user1, "Content1");
+
+        Page<Comment> commentPage = new PageImpl<>(List.of(c1));
+
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+        given(commentRepository.findByPost(any(Post.class), any(PageRequest.class))).willReturn(commentPage);
+
+        given(userRepository.findAllByIdIn(anySet())).willReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> commentService.getCommentList(postId, 1))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("updateComment: 작성자 본인이면 댓글을 수정한다")
+    void updateComment_success() {
+        Long commentId = 100L;
+        Long userId = 1L;
+        CreateCommentRequest request = new CreateCommentRequest("Updated Content");
+
+        User user = newUser(userId);
+        Post post = newPost(10L);
+        Comment comment = newComment(commentId, post, user, "Old Content");
+
+        given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
+        given(userRepository.findByIdOrThrow(userId)).willReturn(user);
+
+        CommentResponse expectedResponse = new CommentResponse(commentId, "Updated Content", null, null);
+        given(commentMapper.toCommentResponse(comment, user)).willReturn(expectedResponse);
+
+        CommentResponse response = commentService.updateComment(commentId, userId, request);
+
+        assertThat(response.content()).isEqualTo("Updated Content");
+
+        assertThat(comment.getContent()).isEqualTo("Updated Content");
+    }
+
+    @Test
+    @DisplayName("updateComment: 작성자가 아니면 AUTH_FORBIDDEN 예외 발생")
+    void updateComment_forbidden_throws() {
+        Long commentId = 100L;
+        Long ownerId = 1L;
+        Long otherId = 2L;
+
+        User owner = newUser(ownerId);
+        User otherUser = newUser(otherId);
+        Comment comment = newComment(commentId, newPost(10L), owner, "Old Content");
+
+        given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
+        given(userRepository.findByIdOrThrow(otherId)).willReturn(otherUser);
+
+        Throwable thrown = catchThrowable(() -> commentService.updateComment(commentId, otherId, new CreateCommentRequest("New")));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_FORBIDDEN);
+
+        assertThat(comment.getContent()).isEqualTo("Old Content");
+    }
+
+    @Test
+    @DisplayName("deleteComment: 작성자 본인이면 댓글을 삭제하고 카운트를 감소시킨다")
+    void deleteComment_success() {
+        Long commentId = 100L;
+        Long userId = 1L;
+        Long postId = 10L;
+
+        User user = newUser(userId);
+        Post post = newPost(postId);
+        Comment comment = newComment(commentId, post, user, "Content");
+
+        given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
+        given(userRepository.findByIdOrThrow(userId)).willReturn(user);
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+
+        commentService.deleteComment(commentId, userId);
+
+        assertThat(comment.getDeletedAt()).isNotNull();
+
+        verify(postCommentCounter).decreaseCommentCount(postId);
+    }
+
+    @Test
+    @DisplayName("deleteComment: 작성자가 아니면 AUTH_FORBIDDEN 예외 발생")
+    void deleteComment_forbidden_throws() {
+        Long commentId = 100L;
+        Long ownerId = 1L;
+        Long otherId = 2L;
+        Long postId = 10L;
+
+        User owner = newUser(ownerId);
+        User otherUser = newUser(otherId);
+        Post post = newPost(postId);
+        Comment comment = newComment(commentId, post, owner, "Content");
+
+        given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
+        given(userRepository.findByIdOrThrow(otherId)).willReturn(otherUser);
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+
+
+        Throwable thrown = catchThrowable(() -> commentService.deleteComment(commentId, otherId));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_FORBIDDEN);
+
+        assertThat(comment.getDeletedAt()).isNull();
+        verify(postCommentCounter, never()).decreaseCommentCount(any());
+    }
+}

--- a/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
@@ -234,7 +234,6 @@ class CommentServiceTest {
 
         given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
         given(userRepository.findByIdOrThrow(otherId)).willReturn(otherUser);
-        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
 
 
         Throwable thrown = catchThrowable(() -> commentService.deleteComment(commentId, otherId));

--- a/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentServiceTest.java
@@ -25,12 +25,14 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static com.example.ktb3community.TestEntityFactory.comment;
+import static com.example.ktb3community.TestEntityFactory.post;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
@@ -52,24 +54,6 @@ class CommentServiceTest {
     @InjectMocks
     CommentService commentService;
 
-    private User newUser(Long id) {
-        User user = User.builder().nickname("nick").build();
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
-    }
-
-    private Post newPost(Long id) {
-        Post post = Post.builder().build();
-        ReflectionTestUtils.setField(post, "id", id);
-        return post;
-    }
-
-    private Comment newComment(Long id, Post post, User user, String content) {
-        Comment comment = Comment.createNew(post, user, content);
-        ReflectionTestUtils.setField(comment, "id", id);
-        return comment;
-    }
-
     @Test
     @DisplayName("createComment: 댓글 저장 후 카운트를 증가시키고 응답을 반환한다")
     void createComment_success() {
@@ -77,9 +61,9 @@ class CommentServiceTest {
         Long userId = 1L;
         CreateCommentRequest request = new CreateCommentRequest("New Comment");
 
-        User user = newUser(userId);
-        Post post = newPost(postId);
-        Comment savedComment = newComment(100L, post, user, "New Comment");
+        User user = user().id(userId).nickname("nick").build();
+        Post post = post().id(postId).build();
+        Comment savedComment = comment(post, user).id(100L).content("New Comment").build();
 
         given(userRepository.findByIdOrThrow(userId)).willReturn(user);
         given(postRepository.findByIdOrThrow(postId)).willReturn(post);
@@ -104,12 +88,12 @@ class CommentServiceTest {
     @DisplayName("getCommentList: 댓글 목록과 작성자 정보를 매핑하여 반환한다")
     void getCommentList_success() {
         Long postId = 10L;
-        Post post = newPost(postId);
-        User user1 = newUser(1L);
-        User user2 = newUser(2L);
+        Post post = post().id(postId).build();
+        User user1 = user().id(1L).nickname("nick").build();
+        User user2 = user().id(2L).nickname("nick").build();
 
-        Comment c1 = newComment(100L, post, user1, "Content1");
-        Comment c2 = newComment(101L, post, user2, "Content2");
+        Comment c1 = comment(post, user1).id(100L).content("Content1").build();
+        Comment c2 = comment(post, user2).id(101L).content("Content2").build();
 
         Page<Comment> commentPage = new PageImpl<>(List.of(c1, c2));
 
@@ -134,9 +118,9 @@ class CommentServiceTest {
     @DisplayName("getCommentList: 작성자 정보가 없으면 UserNotFoundException 발생")
     void getCommentList_userNotFound_throws() {
         Long postId = 10L;
-        Post post = newPost(postId);
-        User user1 = newUser(1L);
-        Comment c1 = newComment(100L, post, user1, "Content1");
+        Post post = post().id(postId).build();
+        User user1 = user().id(1L).nickname("nick").build();
+        Comment c1 = comment(post, user1).id(100L).content("Content1").build();
 
         Page<Comment> commentPage = new PageImpl<>(List.of(c1));
 
@@ -156,9 +140,9 @@ class CommentServiceTest {
         Long userId = 1L;
         CreateCommentRequest request = new CreateCommentRequest("Updated Content");
 
-        User user = newUser(userId);
-        Post post = newPost(10L);
-        Comment comment = newComment(commentId, post, user, "Old Content");
+        User user = user().id(userId).nickname("nick").build();
+        Post post = post().id(10L).build();
+        Comment comment = comment(post, user).id(commentId).content("Old Content").build();
 
         given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
         given(userRepository.findByIdOrThrow(userId)).willReturn(user);
@@ -180,9 +164,9 @@ class CommentServiceTest {
         Long ownerId = 1L;
         Long otherId = 2L;
 
-        User owner = newUser(ownerId);
-        User otherUser = newUser(otherId);
-        Comment comment = newComment(commentId, newPost(10L), owner, "Old Content");
+        User owner = user().id(ownerId).nickname("nick").build();
+        User otherUser = user().id(otherId).nickname("nick").build();
+        Comment comment = comment(post().id(10L).build(), owner).id(commentId).content("Old Content").build();
 
         given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
         given(userRepository.findByIdOrThrow(otherId)).willReturn(otherUser);
@@ -204,9 +188,9 @@ class CommentServiceTest {
         Long userId = 1L;
         Long postId = 10L;
 
-        User user = newUser(userId);
-        Post post = newPost(postId);
-        Comment comment = newComment(commentId, post, user, "Content");
+        User user = user().id(userId).nickname("nick").build();
+        Post post = post().id(postId).build();
+        Comment comment = comment(post, user).id(commentId).content("Content").build();
 
         given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
         given(userRepository.findByIdOrThrow(userId)).willReturn(user);
@@ -227,10 +211,10 @@ class CommentServiceTest {
         Long otherId = 2L;
         Long postId = 10L;
 
-        User owner = newUser(ownerId);
-        User otherUser = newUser(otherId);
-        Post post = newPost(postId);
-        Comment comment = newComment(commentId, post, owner, "Content");
+        User owner = user().id(ownerId).nickname("nick").build();
+        User otherUser = user().id(otherId).nickname("nick").build();
+        Post post = post().id(postId).build();
+        Comment comment = comment(post, owner).id(commentId).content("Content").build();
 
         given(commentRepository.findByIdOrThrow(commentId)).willReturn(comment);
         given(userRepository.findByIdOrThrow(otherId)).willReturn(otherUser);

--- a/src/test/java/com/example/ktb3community/comment/CommentTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentTest.java
@@ -1,0 +1,190 @@
+package com.example.ktb3community.comment;
+
+import com.example.ktb3community.comment.domain.Comment;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.post.exception.PostNotFoundException;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.exception.UserNotFoundException;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class CommentTest {
+
+    private User newUser() {
+        User user = User.builder()
+                .email("test@email.com")
+                .nickname("tester")
+                .build();
+        ReflectionTestUtils.setField(user, "id", USER_ID);
+        return user;
+    }
+
+    private Post newPost() {
+        Post post = Post.builder()
+                .title("Post Title")
+                .build();
+        ReflectionTestUtils.setField(post, "id", POST_ID);
+        return post;
+    }
+
+    @Test
+    @DisplayName("createNew: 댓글 생성 시 내용과 연관관계가 설정되고 deletedAt은 null이다")
+    void createNew_success() {
+        User user = newUser();
+        Post post = newPost();
+        String content = "Nice comment!";
+
+        Comment comment = Comment.createNew(post, user, content);
+
+        assertThat(comment.getContent()).isEqualTo(content);
+        assertThat(comment.getPost()).isEqualTo(post);
+        assertThat(comment.getUser()).isEqualTo(user);
+        assertThat(comment.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("updateContent: 내용이 null이거나 공백이 아니면 수정된다")
+    void updateContent_success() {
+        Comment comment = Comment.createNew(newPost(), newUser(), "Old Content");
+
+        comment.updateContent("New Content");
+
+        assertThat(comment.getContent()).isEqualTo("New Content");
+    }
+
+    @Test
+    @DisplayName("updateContent: 내용이 null이거나 공백이면 수정되지 않는다")
+    void updateContent_ignoreInvalid() {
+        String initialContent = "Original Content";
+        Comment comment = Comment.createNew(newPost(), newUser(), initialContent);
+
+        comment.updateContent(null);
+        assertThat(comment.getContent()).isEqualTo(initialContent);
+
+        comment.updateContent("   ");
+        assertThat(comment.getContent()).isEqualTo(initialContent);
+    }
+
+    @Test
+    @DisplayName("delete: 삭제 시간을 설정하며 멱등성을 보장한다")
+    void delete_success() {
+        Comment comment = Comment.createNew(newPost(), newUser(), "Content");
+        Instant now = Instant.now();
+
+        comment.delete(now);
+        assertThat(comment.getDeletedAt()).isEqualTo(now);
+
+        comment.delete(now.plusSeconds(100));
+        assertThat(comment.getDeletedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("getUserId: User가 존재하면 ID를 반환한다")
+    void getUserId_success() {
+        User user = newUser();
+        Comment comment = Comment.createNew(newPost(), user, "Content");
+
+        assertThat(comment.getUserId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("getUserId: User가 null이면 UserNotFoundException을 던진다")
+    void getUserId_null_throws() {
+        Comment comment = Comment.builder()
+                .post(newPost())
+                .user(null)
+                .content("Content")
+                .build();
+
+        assertThatThrownBy(comment::getUserId)
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getPostId: Post가 존재하면 ID를 반환한다")
+    void getPostId_success() {
+        Post post = newPost();
+        Comment comment = Comment.createNew(post, newUser(), "Content");
+
+        assertThat(comment.getPostId()).isEqualTo(post.getId());
+    }
+
+    @Test
+    @DisplayName("getPostId: Post가 null이면 PostNotFoundException을 던진다")
+    void getPostId_null_throws() {
+        Comment comment = Comment.builder()
+                .post(null)
+                .user(newUser())
+                .content("Content")
+                .build();
+
+        assertThatThrownBy(comment::getPostId)
+                .isInstanceOf(PostNotFoundException.class);
+    }
+    @Test
+    @DisplayName("equals & hashCode: ID가 같으면 동등한 객체다")
+    void equals_identity() {
+        Comment comment1 = Comment.builder().build();
+        ReflectionTestUtils.setField(comment1, "id", 1L);
+
+        Comment comment2 = Comment.builder().build();
+        ReflectionTestUtils.setField(comment2, "id", 1L);
+
+        assertThat(comment1).isEqualTo(comment2);
+        assertThat(comment1.hashCode()).isEqualTo(comment2.hashCode());
+    }
+
+    @Test
+    @DisplayName("equals: ID가 다르면 다른 객체다")
+    void equals_differentId_isNotEqual() {
+        Comment comment1 = Comment.builder().build();
+        ReflectionTestUtils.setField(comment1, "id", 1L);
+
+        Comment comment2 = Comment.builder().build();
+        ReflectionTestUtils.setField(comment2, "id", 2L);
+
+        AssertionsForClassTypes.assertThat(comment1).isNotEqualTo(comment2);
+    }
+
+    @Test
+    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다")
+    void equals_nullId_isNotEqual() {
+        Comment comment1 = Comment.builder().build();
+        Comment comment2 = Comment.builder().build();
+
+        AssertionsForClassTypes.assertThat(comment1).isNotEqualTo(comment2);
+    }
+
+    @Test
+    @DisplayName("equals: 자기 자신과는 항상 동등하다")
+    void equals_self_isEqual() {
+        Comment comment = Comment.builder().build();
+        ReflectionTestUtils.setField(comment, "id", 1L);
+
+        AssertionsForClassTypes.assertThat(comment).isEqualTo(comment);
+    }
+
+    @Test
+    @DisplayName("equals: 프록시 객체와 비교해도 ID가 같으면 동등하다")
+    void equals_proxy() {
+        Comment original = Comment.builder().build();
+        ReflectionTestUtils.setField(original, "id", 100L);
+
+        Comment proxy = new Comment() {
+            @Override
+            public Long getId() {
+                return 100L;
+            }
+        };
+        assertThat(original).isEqualTo(proxy);
+    }
+}

--- a/src/test/java/com/example/ktb3community/comment/CommentTest.java
+++ b/src/test/java/com/example/ktb3community/comment/CommentTest.java
@@ -14,33 +14,18 @@ import java.time.Instant;
 
 import static com.example.ktb3community.TestFixtures.POST_ID;
 import static com.example.ktb3community.TestFixtures.USER_ID;
+import static com.example.ktb3community.TestEntityFactory.post;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class CommentTest {
 
-    private User newUser() {
-        User user = User.builder()
-                .email("test@email.com")
-                .nickname("tester")
-                .build();
-        ReflectionTestUtils.setField(user, "id", USER_ID);
-        return user;
-    }
-
-    private Post newPost() {
-        Post post = Post.builder()
-                .title("Post Title")
-                .build();
-        ReflectionTestUtils.setField(post, "id", POST_ID);
-        return post;
-    }
-
     @Test
     @DisplayName("createNew: 댓글 생성 시 내용과 연관관계가 설정되고 deletedAt은 null이다")
     void createNew_success() {
-        User user = newUser();
-        Post post = newPost();
+        User user = user().id(USER_ID).build();
+        Post post = post().id(POST_ID).title("Post Title").build();
         String content = "Nice comment!";
 
         Comment comment = Comment.createNew(post, user, content);
@@ -54,7 +39,7 @@ class CommentTest {
     @Test
     @DisplayName("updateContent: 내용이 null이거나 공백이 아니면 수정된다")
     void updateContent_success() {
-        Comment comment = Comment.createNew(newPost(), newUser(), "Old Content");
+        Comment comment = Comment.createNew(post().build(), user().build(), "Old Content");
 
         comment.updateContent("New Content");
 
@@ -65,7 +50,7 @@ class CommentTest {
     @DisplayName("updateContent: 내용이 null이거나 공백이면 수정되지 않는다")
     void updateContent_ignoreInvalid() {
         String initialContent = "Original Content";
-        Comment comment = Comment.createNew(newPost(), newUser(), initialContent);
+        Comment comment = Comment.createNew(post().build(), user().build(), initialContent);
 
         comment.updateContent(null);
         assertThat(comment.getContent()).isEqualTo(initialContent);
@@ -77,7 +62,7 @@ class CommentTest {
     @Test
     @DisplayName("delete: 삭제 시간을 설정하며 멱등성을 보장한다")
     void delete_success() {
-        Comment comment = Comment.createNew(newPost(), newUser(), "Content");
+        Comment comment = Comment.createNew(post().build(), user().build(), "Content");
         Instant now = Instant.now();
 
         comment.delete(now);
@@ -90,8 +75,8 @@ class CommentTest {
     @Test
     @DisplayName("getUserId: User가 존재하면 ID를 반환한다")
     void getUserId_success() {
-        User user = newUser();
-        Comment comment = Comment.createNew(newPost(), user, "Content");
+        User user = user().build();
+        Comment comment = Comment.createNew(post().build(), user, "Content");
 
         assertThat(comment.getUserId()).isEqualTo(user.getId());
     }
@@ -100,7 +85,7 @@ class CommentTest {
     @DisplayName("getUserId: User가 null이면 UserNotFoundException을 던진다")
     void getUserId_null_throws() {
         Comment comment = Comment.builder()
-                .post(newPost())
+                .post(post().build())
                 .user(null)
                 .content("Content")
                 .build();
@@ -112,8 +97,8 @@ class CommentTest {
     @Test
     @DisplayName("getPostId: Post가 존재하면 ID를 반환한다")
     void getPostId_success() {
-        Post post = newPost();
-        Comment comment = Comment.createNew(post, newUser(), "Content");
+        Post post = post().build();
+        Comment comment = Comment.createNew(post, user().build(), "Content");
 
         assertThat(comment.getPostId()).isEqualTo(post.getId());
     }
@@ -123,7 +108,7 @@ class CommentTest {
     void getPostId_null_throws() {
         Comment comment = Comment.builder()
                 .post(null)
-                .user(newUser())
+                .user(user().build())
                 .content("Content")
                 .build();
 

--- a/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
@@ -1,0 +1,118 @@
+package com.example.ktb3community.jwt;
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.auth.security.CustomUserDetailsService;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.security.core.context.SecurityContextHolder;
+
+import java.io.IOException;
+import java.util.Collections;
+
+import static com.example.ktb3community.auth.security.SecurityPaths.PUBLIC_AUTH;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class JwtAuthenticationFilterTest {
+
+    @Mock JwtTokenProvider jwtTokenProvider;
+    @Mock CustomUserDetailsService userDetailsService;
+    @Mock FilterChain filterChain;
+
+    @InjectMocks JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    @AfterEach
+    void tearDown() {
+        SecurityContextHolder.clearContext();
+    }
+
+    @Test
+    @DisplayName("헤더에 Authorization이 없으면 인증 없이 다음 필터로 진행한다")
+    void doFilterInternal_noHeader_continueChain() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("Bearer 토큰 형식이 아니면 인증 없이 다음 필터로 진행한다")
+    void doFilterInternal_invalidHeaderFormat_continueChain() throws ServletException, IOException {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Basic aw3d523");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+    }
+
+    @Test
+    @DisplayName("유효한 토큰이 있으면 인증 객체를 SecurityContext에 저장하고 다음 필터로 진행한다")
+    void doFilterInternal_validToken_authenticates() throws ServletException, IOException {
+        String token = "valid.access.token";
+        Long userId = 1L;
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        given(jwtTokenProvider.getUserIdFromAccessToken(token)).willReturn(userId);
+
+        CustomUserDetails userDetails = mock(CustomUserDetails.class);
+        given(userDetails.getAuthorities()).willReturn(Collections.emptyList());
+        given(userDetailsService.loadUserByUsername(userId.toString())).willReturn(userDetails);
+
+        jwtAuthenticationFilter.doFilterInternal(request, response, filterChain);
+
+        verify(filterChain).doFilter(request, response);
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNotNull();
+        assertThat(SecurityContextHolder.getContext().getAuthentication().getPrincipal()).isEqualTo(userDetails);
+    }
+
+    @Test
+    @DisplayName("토큰이 유효하지 않은 경우 INVALID_ACCESS_TOKEN 예외를 던진다")
+    void doFilterInternal_invalidToken_throwsException() {
+        String token = "invalid.token";
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader("Authorization", "Bearer " + token);
+        MockHttpServletResponse response = new MockHttpServletResponse();
+
+        given(jwtTokenProvider.getUserIdFromAccessToken(token))
+                .willThrow(new BusinessException(ErrorCode.INVALID_ACCESS_TOKEN));
+
+        assertThatThrownBy(() -> jwtAuthenticationFilter.doFilterInternal(request, response, filterChain))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.AUTH_UNAUTHORIZED);
+
+        verifyNoInteractions(userDetailsService);
+    }
+
+    @Test
+    @DisplayName("공개된 URL(PUBLIC_AUTH)에 포함되면 필터를 실행하지 않아야 한다")
+    void shouldNotFilter_publicUrl_returnsTrue() {
+        String publicPath = PUBLIC_AUTH[0];
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", publicPath);
+
+        boolean result = jwtAuthenticationFilter.shouldNotFilter(request);
+
+        assertThat(result).isTrue();
+    }
+}

--- a/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
@@ -89,7 +89,7 @@ class JwtAuthenticationFilterTest {
 
     @Test
     @DisplayName("토큰이 유효하지 않은 경우 INVALID_ACCESS_TOKEN 예외를 던진다")
-    void doFilterInternal_invalidToken_throwsException() {
+    void doFilterInternal_invalidToken_throws() {
         String token = "invalid.token";
         MockHttpServletRequest request = new MockHttpServletRequest();
         request.addHeader("Authorization", "Bearer " + token);

--- a/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/example/ktb3community/jwt/JwtAuthenticationFilterTest.java
@@ -2,6 +2,7 @@ package com.example.ktb3community.jwt;
 
 import com.example.ktb3community.auth.security.CustomUserDetails;
 import com.example.ktb3community.auth.security.CustomUserDetailsService;
+import com.example.ktb3community.auth.security.SecurityPaths;
 import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
 import jakarta.servlet.FilterChain;
@@ -16,11 +17,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 import java.io.IOException;
 import java.util.Collections;
 
-import static com.example.ktb3community.auth.security.SecurityPaths.PUBLIC_AUTH;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.BDDMockito.given;
@@ -108,10 +109,14 @@ class JwtAuthenticationFilterTest {
     @Test
     @DisplayName("공개된 URL(PUBLIC_AUTH)에 포함되면 필터를 실행하지 않아야 한다")
     void shouldNotFilter_publicUrl_returnsTrue() {
-        String publicPath = PUBLIC_AUTH[0];
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", publicPath);
 
-        boolean result = jwtAuthenticationFilter.shouldNotFilter(request);
+        String pattern = SecurityPaths.PUBLIC_AUTH[0];
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", pattern);
+
+        request.setServletPath(pattern);
+
+        boolean result = Boolean.TRUE.equals(ReflectionTestUtils.invokeMethod(jwtAuthenticationFilter, "shouldNotFilter", request));
 
         assertThat(result).isTrue();
     }

--- a/src/test/java/com/example/ktb3community/jwt/JwtTokenProviderTest.java
+++ b/src/test/java/com/example/ktb3community/jwt/JwtTokenProviderTest.java
@@ -1,0 +1,123 @@
+package com.example.ktb3community.jwt;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.Date;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class JwtTokenProviderTest {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    private static final String TEST_SECRET = "test_secret_key_must_be_over_32_bytes_long_1234";
+    private static final long ACCESS_EXP_MIN = 30;
+    private static final long REFRESH_EXP_DAYS = 7;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider();
+        ReflectionTestUtils.setField(jwtTokenProvider, "secret", TEST_SECRET);
+        ReflectionTestUtils.setField(jwtTokenProvider, "accessExpMinutes", ACCESS_EXP_MIN);
+        ReflectionTestUtils.setField(jwtTokenProvider, "refreshExpDays", REFRESH_EXP_DAYS);
+    }
+
+    @Test
+    @DisplayName("createAccessToken: 유저 ID로 유효한 JWT 액세스 토큰을 생성하고, 파싱하여 ID를 복구할 수 있다")
+    void createAccessToken_success() {
+        Long userId = 100L;
+
+        String token = jwtTokenProvider.createAccessToken(userId);
+
+        assertThat(token).isNotNull();
+        Long parsedUserId = jwtTokenProvider.getUserIdFromAccessToken(token);
+        assertThat(parsedUserId).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("createRefreshToken: 토큰 ID와 유저 ID로 리프레시 토큰을 생성하고, 파싱하여 토큰 ID를 복구할 수 있다")
+    void createRefreshToken_success() {
+        Long refreshTokenId = 555L;
+        Long userId = 100L;
+
+        String token = jwtTokenProvider.createRefreshToken(refreshTokenId, userId);
+
+        assertThat(token).isNotNull();
+        Long parsedTokenId = jwtTokenProvider.getRefreshTokenId(token);
+        assertThat(parsedTokenId).isEqualTo(refreshTokenId);
+    }
+
+    @Test
+    @DisplayName("getUserIdFromAccessToken: 잘못된 토큰(서명 불일치 등) 입력 시 INVALID_ACCESS_TOKEN 예외 발생")
+    void getUserIdFromAccessToken_invalid_throws() {
+        String invalidToken = "invalid.token.structure";
+
+        assertThatThrownBy(() -> jwtTokenProvider.getUserIdFromAccessToken(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ACCESS_TOKEN);
+    }
+
+    @Test
+    @DisplayName("getUserIdFromAccessToken: 다른 시크릿 키로 서명된 토큰은 파싱에 실패한다")
+    void getUserIdFromAccessToken_wrongSignature_throws() {
+        String otherSecret = "other_secret_key_must_be_over_32_bytes_long_9999";
+        String fakeToken = Jwts.builder()
+                .setSubject("100")
+                .signWith(Keys.hmacShaKeyFor(otherSecret.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtTokenProvider.getUserIdFromAccessToken(fakeToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ACCESS_TOKEN);
+    }
+
+    @Test
+    @DisplayName("getRefreshTokenId: 잘못된 토큰 입력 시 INVALID_REFRESH_TOKEN 예외 발생")
+    void getRefreshTokenId_invalid_throws() {
+        String invalidToken = "invalid.token";
+
+        assertThatThrownBy(() -> jwtTokenProvider.getRefreshTokenId(invalidToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
+    @Test
+    @DisplayName("getRefreshExpiresAt: 리프레시 토큰 만료일 계산 로직이 설정값(7일)과 근사한지 확인")
+    void getRefreshExpiresAt_check() {
+        Instant now = Instant.now();
+
+        Instant expiresAt = jwtTokenProvider.getRefreshExpiresAt();
+
+        Instant expected = now.plus(REFRESH_EXP_DAYS, ChronoUnit.DAYS);
+        long diffSeconds = Math.abs(expected.getEpochSecond() - expiresAt.getEpochSecond());
+
+        assertThat(diffSeconds).isLessThan(60);
+    }
+
+    @Test
+    @DisplayName("만료된 토큰 파싱 시 예외가 발생한다")
+    void parse_expired_token_throws() {
+        Date past = Date.from(Instant.now().minus(1, ChronoUnit.HOURS));
+        String expiredToken = Jwts.builder()
+                .setSubject("100")
+                .setExpiration(past)
+                .signWith(Keys.hmacShaKeyFor(TEST_SECRET.getBytes(StandardCharsets.UTF_8)), SignatureAlgorithm.HS256)
+                .compact();
+
+        assertThatThrownBy(() -> jwtTokenProvider.getUserIdFromAccessToken(expiredToken))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.INVALID_ACCESS_TOKEN);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/LikeTest.java
+++ b/src/test/java/com/example/ktb3community/post/LikeTest.java
@@ -1,0 +1,99 @@
+package com.example.ktb3community.post;
+
+import com.example.ktb3community.post.domain.Like;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class LikeTest {
+
+    private User newUser() {
+        return User.builder().id(1L).build();
+    }
+
+    private Post newPost() {
+        return Post.builder().id(1L).build();
+    }
+
+    @Test
+    @DisplayName("createNew: 좋아요 생성 시 deletedAt은 null이다")
+    void createNew_success() {
+        Post post = newPost();
+        User user = newUser();
+
+        Like like = Like.createNew(post, user);
+
+        assertThat(like.getPost()).isEqualTo(post);
+        assertThat(like.getUser()).isEqualTo(user);
+        assertThat(like.getDeletedAt()).isNull();
+        assertThat(like.isDeleted()).isFalse();
+    }
+
+    @Test
+    @DisplayName("delete: 좋아요 취소 시 deletedAt이 현재 시간으로 설정된다")
+    void delete_success() {
+        Like like = Like.createNew(newPost(), newUser());
+        Instant now = Instant.now();
+
+        like.delete(now);
+
+        assertThat(like.isDeleted()).isTrue();
+        assertThat(like.getDeletedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("delete: 이미 취소된 좋아요를 다시 취소해도 시간은 변경되지 않는다")
+    void delete_idempotent() {
+        Like like = Like.createNew(newPost(), newUser());
+        Instant firstTime = Instant.parse("2025-01-01T10:00:00Z");
+        Instant secondTime = Instant.parse("2025-01-01T12:00:00Z");
+
+        like.delete(firstTime);
+        like.delete(secondTime);
+
+        assertThat(like.getDeletedAt()).isEqualTo(firstTime);
+    }
+
+    @Test
+    @DisplayName("restore: 삭제된 좋아요를 복구하면 deletedAt이 null이 된다")
+    void restore_success() {
+        Like like = Like.createNew(newPost(), newUser());
+        like.delete(Instant.now());
+        assertThat(like.isDeleted()).isTrue();
+
+        like.restore();
+
+        assertThat(like.isDeleted()).isFalse();
+        assertThat(like.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("restore: 이미 활성화된 좋아요를 복구해도 변화가 없다")
+    void restore_idempotent() {
+        Like like = Like.createNew(newPost(), newUser());
+
+        like.restore();
+
+        assertThat(like.isDeleted()).isFalse();
+        assertThat(like.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("isDeleted: deletedAt 값 유무에 따른 상태 반환 확인")
+    void isDeleted_check() {
+        Like like = Like.builder().build();
+
+        assertThat(like.isDeleted()).isFalse();
+
+        like.delete(Instant.now());
+        assertThat(like.isDeleted()).isTrue();
+
+        like.restore();
+        assertThat(like.isDeleted()).isFalse();
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/PostControllerTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostControllerTest.java
@@ -1,0 +1,173 @@
+package com.example.ktb3community.post;
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.common.pagination.PageResponse;
+import com.example.ktb3community.post.controller.PostController;
+import com.example.ktb3community.post.dto.CreatePostRequest;
+import com.example.ktb3community.post.dto.CreatePostResponse;
+import com.example.ktb3community.post.dto.PostDetailResponse;
+import com.example.ktb3community.post.dto.PostListResponse;
+import com.example.ktb3community.post.service.PostService;
+import com.example.ktb3community.post.service.PostViewService;
+import com.example.ktb3community.user.domain.User;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(PostController.class)
+class PostControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @Autowired ObjectMapper objectMapper;
+
+    @MockitoBean
+    PostService postService;
+
+    @MockitoBean
+    PostViewService postViewService;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = User.builder()
+                .id(USER_ID)
+                .email("test@email.com")
+                .role(com.example.ktb3community.common.Role.ROLE_USER)
+                .build();
+
+        CustomUserDetails principal = CustomUserDetails.from(mockUser);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("[201] 게시글 생성 성공")
+    void createPost_201() throws Exception {
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", "http://img.url");
+        CreatePostResponse response = new CreatePostResponse(POST_ID);
+
+        given(postService.createPost(eq(USER_ID), any(CreatePostRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.data.postId").value(POST_ID));
+    }
+
+    @Test
+    @DisplayName("[422] 제목이 없으면 유효성 검사 실패")
+    void createPost_422_invalid() throws Exception {
+        CreatePostRequest invalidRequest = new CreatePostRequest("", "Content", "img");
+
+        mockMvc.perform(post("/posts")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+                        .with(csrf()))
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 게시글 목록 조회 성공")
+    void list_200() throws Exception {
+        PageResponse<PostListResponse> response = new PageResponse<>(Collections.emptyList(), 1, 10, 0);
+
+        given(postViewService.getPostList(anyInt(), anyInt(), any(PostSort.class)))
+                .willReturn(response);
+
+        mockMvc.perform(get("/posts")
+                        .param("page", "1")
+                        .param("pageSize", "10")
+                        .param("sort", "NEW")
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[400] page가 1 미만이면 예외 발생")
+    void list_400_invalidPage() throws Exception {
+        mockMvc.perform(get("/posts")
+                        .param("page", "0")
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PAGE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[400] pageSize가 범위를 벗어나면(21) 예외 발생")
+    void list_400_invalidPageSize() throws Exception {
+        mockMvc.perform(get("/posts")
+                        .param("page", "1")
+                        .param("pageSize", "21") // 21개 요청
+                        .with(csrf()))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_PAGE_SIZE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 게시글 상세 조회 성공")
+    void getPostDetail_200() throws Exception {
+        PostDetailResponse response = new PostDetailResponse(POST_ID, "Title", "Content", null, null, 0, 0, 0, false, null, null);
+
+        given(postViewService.getPostDetail(POST_ID, USER_ID)).willReturn(response);
+
+        mockMvc.perform(get("/posts/{postId}", POST_ID)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.postId").value(POST_ID))
+                .andExpect(jsonPath("$.data.title").value("Title"));
+    }
+
+    @Test
+    @DisplayName("[200] 게시글 수정 성공")
+    void updatePost_200() throws Exception {
+        CreatePostRequest request = new CreatePostRequest("New Title", "New Content", "img");
+        CreatePostResponse response = new CreatePostResponse(POST_ID);
+
+        given(postService.updatePost(eq(POST_ID), eq(USER_ID), any(CreatePostRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/posts/{postId}", POST_ID)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("[204] 게시글 삭제 성공")
+    void deletePost_204() throws Exception {
+        mockMvc.perform(delete("/posts/{postId}", POST_ID)
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+
+        verify(postService).deletePost(POST_ID, USER_ID);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/PostControllerTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostControllerTest.java
@@ -66,7 +66,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[201] 게시글 생성 성공")
-    void createPost_201() throws Exception {
+    void createPost_201_success() throws Exception {
         CreatePostRequest request = new CreatePostRequest("Title", "Content", "http://img.url");
         CreatePostResponse response = new CreatePostResponse(POST_ID);
 
@@ -83,7 +83,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[422] 제목이 없으면 유효성 검사 실패")
-    void createPost_422_invalid() throws Exception {
+    void createPost_422_invalidInput() throws Exception {
         CreatePostRequest invalidRequest = new CreatePostRequest("", "Content", "img");
 
         mockMvc.perform(post("/posts")
@@ -96,7 +96,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[200] 게시글 목록 조회 성공")
-    void list_200() throws Exception {
+    void list_200_success() throws Exception {
         PageResponse<PostListResponse> response = new PageResponse<>(Collections.emptyList(), 1, 10, 0);
 
         given(postViewService.getPostList(anyInt(), anyInt(), any(PostSort.class)))
@@ -133,7 +133,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[200] 게시글 상세 조회 성공")
-    void getPostDetail_200() throws Exception {
+    void getPostDetail_200_success() throws Exception {
         PostDetailResponse response = new PostDetailResponse(POST_ID, "Title", "Content", null, null, 0, 0, 0, false, null, null);
 
         given(postViewService.getPostDetail(POST_ID, USER_ID)).willReturn(response);
@@ -147,7 +147,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[200] 게시글 수정 성공")
-    void updatePost_200() throws Exception {
+    void updatePost_200_success() throws Exception {
         CreatePostRequest request = new CreatePostRequest("New Title", "New Content", "img");
         CreatePostResponse response = new CreatePostResponse(POST_ID);
 
@@ -163,7 +163,7 @@ class PostControllerTest {
 
     @Test
     @DisplayName("[204] 게시글 삭제 성공")
-    void deletePost_204() throws Exception {
+    void deletePost_204_success() throws Exception {
         mockMvc.perform(delete("/posts/{postId}", POST_ID)
                         .with(csrf()))
                 .andExpect(status().isNoContent());

--- a/src/test/java/com/example/ktb3community/post/PostServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostServiceTest.java
@@ -25,11 +25,9 @@ import java.time.Instant;
 import static com.example.ktb3community.TestFixtures.POST_ID;
 import static com.example.ktb3community.TestFixtures.USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 

--- a/src/test/java/com/example/ktb3community/post/PostServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostServiceTest.java
@@ -48,7 +48,7 @@ class PostServiceTest {
     @DisplayName("createPost: 게시글이 정상적으로 저장되고 ID를 반환한다")
     void createPost_success() {
         CreatePostRequest request = new CreatePostRequest("Title", "Content", "http://image.url");
-        User user = user().build();
+        User user = user().id(USER_ID).build();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
 
@@ -75,8 +75,13 @@ class PostServiceTest {
     @DisplayName("updatePost: 작성자 본인이면 게시글을 수정하고, 기존 이미지가 변경되면 파일 삭제 로직을 호출한다")
     void updatePost_success() {
         CreatePostRequest request = new CreatePostRequest("New Title", "New Content", "http://new-image.com");
-        User user = user().build();
-        Post post = post(user).title("Old Title").content("Old Content").postImageUrl("http://old-image.com").build();
+        User user = user().id(USER_ID).build();
+        Post post = post(user)
+                .id(POST_ID)
+                .title("Old Title")
+                .content("Old Content")
+                .postImageUrl("http://old-image.com")
+                .build();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
         given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
@@ -96,8 +101,13 @@ class PostServiceTest {
     @DisplayName("updatePost: 작성자가 아니면 AUTH_FORBIDDEN 예외가 발생한다")
     void updatePost_notOwner_throws() {
         CreatePostRequest request = new CreatePostRequest("Title", "Content", "Img");
-        User owner = user().build(); // ID: 1L
-        Post post = post(owner).title("Old Title").content("Old Content").postImageUrl("http://old-image.com").build();
+        User owner = user().id(USER_ID).build(); // ID: 1L
+        Post post = post(owner)
+                .id(POST_ID)
+                .title("Old Title")
+                .content("Old Content")
+                .postImageUrl("http://old-image.com")
+                .build();
 
         Long otherUserId = 999L; // 다른 유저 ID
 
@@ -117,8 +127,8 @@ class PostServiceTest {
     @Test
     @DisplayName("deletePost: 작성자 본인이면 댓글과 게시글을 소프트 삭제한다")
     void deletePost_success() {
-        User user = user().build();
-        Post post = post(user).build();
+        User user = user().id(USER_ID).build();
+        Post post = post(user).id(POST_ID).build();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
         given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
@@ -133,8 +143,8 @@ class PostServiceTest {
     @Test
     @DisplayName("deletePost: 작성자가 아니면 AUTH_FORBIDDEN 예외가 발생한다")
     void deletePost_notOwner_throws() {
-        User owner = user().build(); // ID: 1L
-        Post post = post(owner).build();
+        User owner = user().id(USER_ID).build(); // ID: 1L
+        Post post = post(owner).id(POST_ID).build();
         Long otherUserId = 999L;
 
         given(userRepository.findByIdOrThrow(otherUserId)).willReturn(user().id(otherUserId).build());
@@ -153,7 +163,7 @@ class PostServiceTest {
     @Test
     @DisplayName("increaseCommentCount: 게시글의 댓글 카운트를 1 증가시킨다")
     void increaseCommentCount_success() {
-        Post post = post(user().build()).build();
+        Post post = post(user().id(USER_ID).build()).id(POST_ID).build();
         given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
 
         postService.increaseCommentCount(POST_ID);
@@ -164,7 +174,7 @@ class PostServiceTest {
     @Test
     @DisplayName("decreaseCommentCount: 게시글의 댓글 카운트를 1 감소시킨다")
     void decreaseCommentCount_success() {
-        Post post = post(user().build()).build();
+        Post post = post(user().id(USER_ID).build()).id(POST_ID).build();
         post.increaseCommentCount();
         given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
 

--- a/src/test/java/com/example/ktb3community/post/PostServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostServiceTest.java
@@ -1,0 +1,193 @@
+package com.example.ktb3community.post;
+
+import com.example.ktb3community.comment.repository.CommentRepository;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.post.dto.CreatePostRequest;
+import com.example.ktb3community.post.dto.CreatePostResponse;
+import com.example.ktb3community.post.repository.PostRepository;
+import com.example.ktb3community.post.service.PostService;
+import com.example.ktb3community.s3.service.FileService;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class PostServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PostRepository postRepository;
+    @Mock CommentRepository commentRepository;
+    @Mock FileService fileService;
+
+    @InjectMocks
+    PostService postService;
+
+    private User newUser() {
+        return User.builder().id(USER_ID).build();
+    }
+
+    private Post newPost(User user) {
+        Post post = Post.builder()
+                .user(user)
+                .title("Old Title")
+                .content("Old Content")
+                .postImageUrl("http://old-image.com")
+                .likeCount(0)
+                .viewCount(0)
+                .commentCount(0)
+                .build();
+        ReflectionTestUtils.setField(post, "id", POST_ID);
+        return post;
+    }
+
+    @Test
+    @DisplayName("createPost: 게시글이 정상적으로 저장되고 ID를 반환한다")
+    void createPost_success() {
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", "http://image.url");
+        User user = newUser();
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+
+        given(postRepository.save(any(Post.class))).willAnswer(invocation -> {
+            Post p = invocation.getArgument(0);
+            ReflectionTestUtils.setField(p, "id", POST_ID);
+            return p;
+        });
+
+        CreatePostResponse response = postService.createPost(USER_ID, request);
+
+        assertThat(response.postId()).isEqualTo(POST_ID);
+
+        ArgumentCaptor<Post> postCaptor = ArgumentCaptor.forClass(Post.class);
+        verify(postRepository).save(postCaptor.capture());
+
+        Post capturedPost = postCaptor.getValue();
+        assertThat(capturedPost.getUser()).isEqualTo(user);
+        assertThat(capturedPost.getTitle()).isEqualTo("Title");
+        assertThat(capturedPost.getContent()).isEqualTo("Content");
+    }
+
+    @Test
+    @DisplayName("updatePost: 작성자 본인이면 게시글을 수정하고, 기존 이미지가 변경되면 파일 삭제 로직을 호출한다")
+    void updatePost_success() {
+        CreatePostRequest request = new CreatePostRequest("New Title", "New Content", "http://new-image.com");
+        User user = newUser();
+        Post post = newPost(user);
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        CreatePostResponse response = postService.updatePost(POST_ID, USER_ID, request);
+
+        assertThat(response.postId()).isEqualTo(POST_ID);
+
+        assertThat(post.getTitle()).isEqualTo("New Title");
+        assertThat(post.getContent()).isEqualTo("New Content");
+        assertThat(post.getPostImageUrl()).isEqualTo("http://new-image.com");
+
+        verify(fileService).deleteImageIfChanged("http://old-image.com", "http://new-image.com");
+    }
+
+    @Test
+    @DisplayName("updatePost: 작성자가 아니면 AUTH_FORBIDDEN 예외가 발생한다")
+    void updatePost_notOwner_throws() {
+        CreatePostRequest request = new CreatePostRequest("Title", "Content", "Img");
+        User owner = newUser(); // ID: 1L
+        Post post = newPost(owner);
+
+        Long otherUserId = 999L; // 다른 유저 ID
+
+        given(userRepository.findByIdOrThrow(otherUserId)).willReturn(User.builder().id(otherUserId).build());
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        Throwable thrown = catchThrowable(() -> postService.updatePost(POST_ID, otherUserId, request));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_FORBIDDEN);
+
+        assertThat(post.getTitle()).isEqualTo("Old Title");
+    }
+
+    @Test
+    @DisplayName("deletePost: 작성자 본인이면 댓글과 게시글을 소프트 삭제한다")
+    void deletePost_success() {
+        User user = newUser();
+        Post post = newPost(user);
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        postService.deletePost(POST_ID, USER_ID);
+
+        verify(commentRepository).softDeleteByPostId(any(Long.class), any(Instant.class));
+
+        assertThat(post.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("deletePost: 작성자가 아니면 AUTH_FORBIDDEN 예외가 발생한다")
+    void deletePost_notOwner_throws() {
+        User owner = newUser(); // ID: 1L
+        Post post = newPost(owner);
+        Long otherUserId = 999L;
+
+        given(userRepository.findByIdOrThrow(otherUserId)).willReturn(User.builder().id(otherUserId).build());
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        Throwable thrown = catchThrowable(() -> postService.deletePost(POST_ID, otherUserId));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.AUTH_FORBIDDEN);
+        verify(commentRepository, times(0)).softDeleteByPostId(any(), any());
+        assertThat(post.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("increaseCommentCount: 게시글의 댓글 카운트를 1 증가시킨다")
+    void increaseCommentCount_success() {
+        Post post = newPost(newUser());
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        postService.increaseCommentCount(POST_ID);
+
+        assertThat(post.getCommentCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("decreaseCommentCount: 게시글의 댓글 카운트를 1 감소시킨다")
+    void decreaseCommentCount_success() {
+        Post post = newPost(newUser());
+        post.increaseCommentCount();
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+
+        postService.decreaseCommentCount(POST_ID);
+
+        assertThat(post.getCommentCount()).isZero();
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/PostTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostTest.java
@@ -1,0 +1,231 @@
+package com.example.ktb3community.post;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.user.domain.User;
+import org.assertj.core.api.AssertionsForClassTypes;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.Instant;
+
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+
+
+class PostTest {
+
+    private User newUser() {
+        return User.builder()
+                .id(USER_ID)
+                .email("user@test.com")
+                .nickname("tester")
+                .build();
+    }
+
+    private Post newPost(User user) {
+        return Post.builder()
+                .user(user)
+                .title("Original Title")
+                .content("Original Content")
+                .postImageUrl("http://original.jpg")
+                .likeCount(0)
+                .viewCount(0)
+                .commentCount(0)
+                .build();
+    }
+
+    @Test
+    @DisplayName("createNew: 제목은 trim되고 초기 카운트는 0으로 생성된다")
+    void createNew_success() {
+        User user = newUser();
+        String title = "  Trimmed Title  ";
+        String content = "Content";
+        String imageUrl = "http://image.url";
+
+        Post post = Post.createNew(user, title, content, imageUrl);
+
+        assertThat(post.getTitle()).isEqualTo("Trimmed Title");
+        assertThat(post.getContent()).isEqualTo("Content");
+        assertThat(post.getPostImageUrl()).isEqualTo("http://image.url");
+        assertThat(post.getUser()).isEqualTo(user);
+
+        assertThat(post.getLikeCount()).isZero();
+        assertThat(post.getViewCount()).isZero();
+        assertThat(post.getCommentCount()).isZero();
+        assertThat(post.getDeletedAt()).isNull();
+    }
+
+    @Test
+    @DisplayName("updatePost: 제목과 내용은 값이 있을 때만 수정되고, 이미지는 무조건 수정된다")
+    void updatePost_success() {
+        Post post = newPost(newUser());
+
+        post.updatePost("  New Title  ", "New Content", "http://new.jpg");
+
+        assertThat(post.getTitle()).isEqualTo("New Title");
+        assertThat(post.getContent()).isEqualTo("New Content");
+        assertThat(post.getPostImageUrl()).isEqualTo("http://new.jpg");
+    }
+
+    @Test
+    @DisplayName("updatePost: 제목과 내용이 null이거나 공백이면 기존 값을 유지한다")
+    void updatePost_ignoreNullOrBlank() {
+        Post post = newPost(newUser());
+        String originalTitle = post.getTitle();
+        String originalContent = post.getContent();
+
+        post.updatePost(null, "   ", "http://changed.jpg");
+
+        assertThat(post.getTitle()).isEqualTo(originalTitle);
+        assertThat(post.getContent()).isEqualTo(originalContent);
+        assertThat(post.getPostImageUrl()).isEqualTo("http://changed.jpg");
+    }
+
+    @Test
+    @DisplayName("updatePost: 이미지는 null이 들어오면 null로 업데이트된다")
+    void updatePost_imageCanBeNull() {
+        Post post = newPost(newUser());
+
+        post.updatePost(null, null, null);
+
+        assertThat(post.getPostImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("increaseViewCount: 조회수가 1 증가한다")
+    void increaseViewCount() {
+        Post post = newPost(newUser());
+
+        post.increaseViewCount();
+
+        assertThat(post.getViewCount()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("LikeCount: 좋아요 증가 및 감소 (0 이하로 내려가지 않아야한다)")
+    void likeCount_logic() {
+        Post post = newPost(newUser());
+
+        post.increaseLikeCount();
+        assertThat(post.getLikeCount()).isEqualTo(1);
+
+        post.decreaseLikeCount();
+        assertThat(post.getLikeCount()).isZero();
+
+        post.decreaseLikeCount();
+        assertThat(post.getLikeCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("CommentCount: 댓글 수 증가 및 감소 (0 이하로 내려가지 않아야한다)")
+    void commentCount_logic() {
+        Post post = newPost(newUser());
+
+        post.increaseCommentCount();
+        assertThat(post.getCommentCount()).isEqualTo(1);
+
+        post.decreaseCommentCount();
+        assertThat(post.getCommentCount()).isZero();
+
+        post.decreaseCommentCount();
+        assertThat(post.getCommentCount()).isZero();
+    }
+
+    @Test
+    @DisplayName("delete: 삭제 시간을 설정하며 멱등성을 보장한다")
+    void delete_idempotent() {
+        Post post = newPost(newUser());
+        Instant now = Instant.now();
+
+        post.delete(now);
+        assertThat(post.getDeletedAt()).isEqualTo(now);
+
+        post.delete(now.plusSeconds(100));
+        assertThat(post.getDeletedAt()).isEqualTo(now);
+    }
+
+    @Test
+    @DisplayName("getUserId: User가 존재하면 ID 반환")
+    void getUserId_success() {
+        User user = newUser();
+        Post post = newPost(user);
+
+        assertThat(post.getUserId()).isEqualTo(user.getId());
+    }
+
+    @Test
+    @DisplayName("getUserId: User가 null이면 예외 발생")
+    void getUserId_nullUser_throws() {
+        Post post = Post.builder().user(null).build();
+
+        Throwable thrown = catchThrowable(post::getUserId);
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("equals & hashCode: ID가 같으면 동등한 객체다")
+    void equals_identity() {
+        Post post1 = Post.builder().build();
+        ReflectionTestUtils.setField(post1, "id", 1L);
+
+        Post post2 = Post.builder().build();
+        ReflectionTestUtils.setField(post2, "id", 1L);
+
+        assertThat(post1).isEqualTo(post2);
+        assertThat(post1.hashCode()).isEqualTo(post2.hashCode());
+    }
+
+    @Test
+    @DisplayName("equals: ID가 다르면 다른 객체다")
+    void equals_differentId_isNotEqual() {
+        Post post1 = newPost(newUser());
+        ReflectionTestUtils.setField(post1, "id", 1L);
+
+        Post post2 = newPost(newUser());
+        ReflectionTestUtils.setField(post2, "id", 2L);
+
+        AssertionsForClassTypes.assertThat(post1).isNotEqualTo(post2);
+    }
+
+    @Test
+    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다(각각 다른 인스턴스)")
+    void equals_nullId_isNotEqual() {
+        Post post1 = newPost(newUser());
+        Post post2 = newPost(newUser());
+
+        AssertionsForClassTypes.assertThat(post1).isNotEqualTo(post2);
+    }
+
+    @Test
+    @DisplayName("equals: 자기 자신과는 항상 동등하다")
+    void equals_self_isEqual() {
+        Post post = newPost(newUser());
+        ReflectionTestUtils.setField(post, "id", 1L);
+
+        AssertionsForClassTypes.assertThat(post).isEqualTo(post);
+    }
+
+    @Test
+    @DisplayName("equals: 프록시 객체와 비교해도 ID가 같으면 동등하다")
+    void equals_proxy() {
+        Post original = Post.builder().build();
+        ReflectionTestUtils.setField(original, "id", 100L);
+
+        Post proxy = new Post() {
+            @Override
+            public Long getId() {
+                return 100L;
+            }
+        };
+
+        assertThat(original).isEqualTo(proxy);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/PostTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostTest.java
@@ -196,7 +196,7 @@ class PostTest {
     }
 
     @Test
-    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다(각각 다른 인스턴스)")
+    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다")
     void equals_nullId_isNotEqual() {
         Post post1 = newPost(newUser());
         Post post2 = newPost(newUser());

--- a/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
@@ -22,12 +22,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
+import static com.example.ktb3community.TestEntityFactory.post;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
@@ -45,37 +46,14 @@ class PostViewServiceTest {
     @InjectMocks
     PostViewService postViewService;
 
-    private User newUser(Long id, String nickname) {
-        User user = User.builder()
-                .email("user@test.com")
-                .nickname(nickname)
-                .profileImageUrl("img")
-                .build();
-        ReflectionTestUtils.setField(user, "id", id);
-        return user;
-    }
-
-    private Post newPost(Long id, User user, String title) {
-        Post post = Post.builder()
-                .user(user)
-                .title(title)
-                .content("Content")
-                .viewCount(0)
-                .likeCount(0)
-                .commentCount(0)
-                .build();
-        ReflectionTestUtils.setField(post, "id", id);
-        return post;
-    }
-
     @Test
     @DisplayName("getPostList: 게시글 목록과 작성자 정보를 정상적으로 매핑하여 반환한다")
     void getPostList_success() {
-        User user1 = newUser(1L, "user1");
-        User user2 = newUser(2L, "user2");
+        User user1 = user().id(1L).nickname("user1").profileImageUrl("img").build();
+        User user2 = user().id(2L).nickname("user2").profileImageUrl("img").build();
 
-        Post post1 = newPost(10L, user1, "Title1");
-        Post post2 = newPost(11L, user2, "Title2");
+        Post post1 = post(user1).id(10L).title("Title1").content("Content").build();
+        Post post2 = post(user2).id(11L).title("Title2").content("Content").build();
 
         List<Post> posts = List.of(post1, post2);
         Page<Post> postPage = new PageImpl<>(posts, PageRequest.of(0, 10), posts.size());
@@ -103,8 +81,8 @@ class PostViewServiceTest {
     @DisplayName("getPostList: 작성자 정보가 DB에 없으면 UserNotFoundException 발생")
     void getPostList_authorNotFound_throws() {
 
-        User user1 = newUser(1L, "user1");
-        Post post1 = newPost(10L, user1, "Title1");
+        User user1 = user().id(1L).nickname("user1").profileImageUrl("img").build();
+        Post post1 = post(user1).id(10L).title("Title1").content("Content").build();
 
         Page<Post> postPage = new PageImpl<>(List.of(post1));
         PostSort sort = mock(PostSort.class);
@@ -124,9 +102,9 @@ class PostViewServiceTest {
         Long viewerId = 99L;
         Long authorId = 1L;
 
-        User author = newUser(authorId, "author");
-        User viewer = newUser(viewerId, "viewer");
-        Post post = newPost(postId, author, "Detail Title");
+        User author = user().id(authorId).nickname("author").profileImageUrl("img").build();
+        User viewer = user().id(viewerId).nickname("viewer").profileImageUrl("img").build();
+        Post post = post(author).id(postId).title("Detail Title").content("Content").build();
 
         given(postRepository.findByIdOrThrow(postId)).willReturn(post);
         given(userRepository.findByIdOrThrow(authorId)).willReturn(author);

--- a/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
@@ -90,7 +90,7 @@ class PostViewServiceTest {
 
         assertThat(response.content()).hasSize(2);
 
-        PostListResponse res1 = response.content().get(0);
+        PostListResponse res1 = response.content().getFirst();
         assertThat(res1.title()).isEqualTo("Title1");
         assertThat(res1.author().nickname()).isEqualTo("user1");
 
@@ -144,7 +144,7 @@ class PostViewServiceTest {
         assertThat(response.postId()).isEqualTo(postId);
         assertThat(response.title()).isEqualTo("Detail Title");
         assertThat(response.author().nickname()).isEqualTo("author");
-        assertThat(response.liked()).isTrue(); 
+        assertThat(response.liked()).isTrue();
         assertThat(response.comments()).isSameAs(emptyComments);
     }
 }

--- a/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/PostViewServiceTest.java
@@ -1,0 +1,150 @@
+package com.example.ktb3community.post;
+
+import com.example.ktb3community.comment.dto.CommentResponse;
+import com.example.ktb3community.comment.service.CommentService;
+import com.example.ktb3community.common.pagination.PageResponse;
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.post.dto.PostDetailResponse;
+import com.example.ktb3community.post.dto.PostListResponse;
+import com.example.ktb3community.post.repository.PostLikeRepository;
+import com.example.ktb3community.post.repository.PostRepository;
+import com.example.ktb3community.post.service.PostViewService;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.exception.UserNotFoundException;
+import com.example.ktb3community.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anySet;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.mock;
+@ExtendWith(MockitoExtension.class)
+class PostViewServiceTest {
+
+    @Mock PostRepository postRepository;
+    @Mock UserRepository userRepository;
+    @Mock PostLikeRepository postLikeRepository;
+    @Mock CommentService commentService;
+
+    @InjectMocks
+    PostViewService postViewService;
+
+    private User newUser(Long id, String nickname) {
+        User user = User.builder()
+                .email("user@test.com")
+                .nickname(nickname)
+                .profileImageUrl("img")
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private Post newPost(Long id, User user, String title) {
+        Post post = Post.builder()
+                .user(user)
+                .title(title)
+                .content("Content")
+                .viewCount(0)
+                .likeCount(0)
+                .commentCount(0)
+                .build();
+        ReflectionTestUtils.setField(post, "id", id);
+        return post;
+    }
+
+    @Test
+    @DisplayName("getPostList: 게시글 목록과 작성자 정보를 정상적으로 매핑하여 반환한다")
+    void getPostList_success() {
+        User user1 = newUser(1L, "user1");
+        User user2 = newUser(2L, "user2");
+
+        Post post1 = newPost(10L, user1, "Title1");
+        Post post2 = newPost(11L, user2, "Title2");
+
+        List<Post> posts = List.of(post1, post2);
+        Page<Post> postPage = new PageImpl<>(posts, PageRequest.of(0, 10), posts.size());
+
+        PostSort sort = mock(PostSort.class);
+        given(sort.sort()).willReturn(Sort.unsorted());
+
+        given(postRepository.findAll(any(PageRequest.class))).willReturn(postPage);
+        given(userRepository.findAllByIdIn(Set.of(1L, 2L))).willReturn(List.of(user1, user2));
+
+        PageResponse<PostListResponse> response = postViewService.getPostList(1, 10, sort);
+
+        assertThat(response.content()).hasSize(2);
+
+        PostListResponse res1 = response.content().get(0);
+        assertThat(res1.title()).isEqualTo("Title1");
+        assertThat(res1.author().nickname()).isEqualTo("user1");
+
+        PostListResponse res2 = response.content().get(1);
+        assertThat(res2.title()).isEqualTo("Title2");
+        assertThat(res2.author().nickname()).isEqualTo("user2");
+    }
+
+    @Test
+    @DisplayName("getPostList: 작성자 정보가 DB에 없으면 UserNotFoundException 발생")
+    void getPostList_authorNotFound_throws() {
+
+        User user1 = newUser(1L, "user1");
+        Post post1 = newPost(10L, user1, "Title1");
+
+        Page<Post> postPage = new PageImpl<>(List.of(post1));
+        PostSort sort = mock(PostSort.class);
+        given(sort.sort()).willReturn(Sort.unsorted());
+
+        given(postRepository.findAll(any(PageRequest.class))).willReturn(postPage);
+        given(userRepository.findAllByIdIn(anySet())).willReturn(Collections.emptyList());
+
+        assertThatThrownBy(() -> postViewService.getPostList(1, 10, sort))
+                .isInstanceOf(UserNotFoundException.class);
+    }
+
+    @Test
+    @DisplayName("getPostDetail: 상세 조회 시 조회수가 1 증가하고 상세 정보를 반환한다")
+    void getPostDetail_success() {
+        Long postId = 10L;
+        Long viewerId = 99L;
+        Long authorId = 1L;
+
+        User author = newUser(authorId, "author");
+        User viewer = newUser(viewerId, "viewer");
+        Post post = newPost(postId, author, "Detail Title");
+
+        given(postRepository.findByIdOrThrow(postId)).willReturn(post);
+        given(userRepository.findByIdOrThrow(authorId)).willReturn(author);
+        given(userRepository.findByIdOrThrow(viewerId)).willReturn(viewer);
+
+        given(postLikeRepository.exists(post, viewer)).willReturn(true);
+
+        PageResponse<CommentResponse> emptyComments = new PageResponse<>(Collections.emptyList(), 1, 10, 0);
+        given(commentService.getCommentList(postId, 1)).willReturn(emptyComments);
+
+        PostDetailResponse response = postViewService.getPostDetail(postId, viewerId);
+
+        assertThat(post.getViewCount()).isEqualTo(1);
+
+        assertThat(response.postId()).isEqualTo(postId);
+        assertThat(response.title()).isEqualTo("Detail Title");
+        assertThat(response.author().nickname()).isEqualTo("author");
+        assertThat(response.liked()).isTrue(); 
+        assertThat(response.comments()).isSameAs(emptyComments);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
@@ -1,0 +1,96 @@
+package com.example.ktb3community.post.like;
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.post.controller.LikeController;
+import com.example.ktb3community.post.dto.LikeResponse;
+import com.example.ktb3community.post.service.LikeService;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(LikeController.class)
+class LikeControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean
+    LikeService likeService;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = User.builder()
+                .id(USER_ID)
+                .email("test@email.com")
+                .role(com.example.ktb3community.common.Role.ROLE_USER)
+                .build();
+
+        CustomUserDetails principal = CustomUserDetails.from(mockUser);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("[200] 게시글 좋아요 성공")
+    void likePost_200() throws Exception {
+        LikeResponse response = new LikeResponse(10L, 5L, 3L);
+
+        given(likeService.likePost(POST_ID, USER_ID)).willReturn(response);
+
+        mockMvc.perform(post("/posts/{postId}/likes", POST_ID)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likeCount").value(10L))
+                .andExpect(jsonPath("$.data.viewCount").value(5L))
+                .andExpect(jsonPath("$.data.commentCount").value(3L));
+
+        verify(likeService).likePost(POST_ID, USER_ID);
+    }
+
+    @Test
+    @DisplayName("[404] 존재하지 않는 게시글에 좋아요 시도 시 예외 발생")
+    void likePost_404_postNotFound() throws Exception {
+        given(likeService.likePost(POST_ID, USER_ID))
+                .willThrow(new BusinessException(ErrorCode.POST_NOT_FOUND));
+
+        mockMvc.perform(post("/posts/{postId}/likes", POST_ID)
+                        .with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.POST_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 게시글 좋아요 취소 성공")
+    void unlikePost_200() throws Exception {
+        LikeResponse response = new LikeResponse(9L, 5L, 3L);
+
+        given(likeService.unlikePost(POST_ID, USER_ID)).willReturn(response);
+
+        mockMvc.perform(delete("/posts/{postId}/likes", POST_ID)
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.likeCount").value(9L));
+
+        verify(likeService).unlikePost(POST_ID, USER_ID);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import static com.example.ktb3community.TestFixtures.POST_ID;
 import static com.example.ktb3community.TestFixtures.USER_ID;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -38,11 +39,7 @@ class LikeControllerTest {
 
     @BeforeEach
     void setUp() {
-        User mockUser = User.builder()
-                .id(USER_ID)
-                .email("test@email.com")
-                .role(com.example.ktb3community.common.Role.ROLE_USER)
-                .build();
+        User mockUser = user().id(USER_ID).build();
 
         CustomUserDetails principal = CustomUserDetails.from(mockUser);
         SecurityContext context = SecurityContextHolder.createEmptyContext();

--- a/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeControllerTest.java
@@ -49,7 +49,7 @@ class LikeControllerTest {
 
     @Test
     @DisplayName("[200] 게시글 좋아요 성공")
-    void likePost_200() throws Exception {
+    void likePost_200_success() throws Exception {
         LikeResponse response = new LikeResponse(10L, 5L, 3L);
 
         given(likeService.likePost(POST_ID, USER_ID)).willReturn(response);
@@ -78,7 +78,7 @@ class LikeControllerTest {
 
     @Test
     @DisplayName("[200] 게시글 좋아요 취소 성공")
-    void unlikePost_200() throws Exception {
+    void unlikePost_200_success() throws Exception {
         LikeResponse response = new LikeResponse(9L, 5L, 3L);
 
         given(likeService.unlikePost(POST_ID, USER_ID)).willReturn(response);

--- a/src/test/java/com/example/ktb3community/post/like/LikeServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeServiceTest.java
@@ -13,10 +13,11 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import org.springframework.test.util.ReflectionTestUtils;
 
 import static com.example.ktb3community.TestFixtures.POST_ID;
 import static com.example.ktb3community.TestFixtures.USER_ID;
+import static com.example.ktb3community.TestEntityFactory.post;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
@@ -31,26 +32,11 @@ class LikeServiceTest {
     @InjectMocks
     LikeService likeService;
 
-
-    private User newUser() {
-        return User.builder().id(USER_ID).build();
-    }
-
-    private Post newPost() {
-        Post post = Post.builder()
-                .likeCount(10)
-                .viewCount(5)
-                .commentCount(3)
-                .build();
-        ReflectionTestUtils.setField(post, "id", POST_ID);
-        return post;
-    }
-
     @Test
     @DisplayName("likePost: 좋아요를 처음 누르면 카운트가 1 증가한다")
     void likePost_added_increasesCount() {
-        User user = newUser();
-        Post post = newPost();
+        User user = user().id(USER_ID).build();
+        Post post = post().id(POST_ID).likeCount(10).viewCount(5).commentCount(3).build();
         long initialCount = post.getLikeCount();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
@@ -68,8 +54,8 @@ class LikeServiceTest {
     @Test
     @DisplayName("likePost: 이미 좋아요를 눌렀던 경우 카운트는 증가하지 않는다")
     void likePost_alreadyLiked_doesNotIncreaseCount() {
-        User user = newUser();
-        Post post = newPost();
+        User user = user().id(USER_ID).build();
+        Post post = post().id(POST_ID).likeCount(10).viewCount(5).commentCount(3).build();
         long initialCount = post.getLikeCount();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
@@ -85,8 +71,8 @@ class LikeServiceTest {
     @Test
     @DisplayName("unlikePost: 좋아요 취소 성공 시 카운트가 1 감소한다")
     void unlikePost_removed_decreasesCount() {
-        User user = newUser();
-        Post post = newPost();
+        User user = user().id(USER_ID).build();
+        Post post = post().id(POST_ID).likeCount(10).viewCount(5).commentCount(3).build();
         long initialCount = post.getLikeCount();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
@@ -104,8 +90,8 @@ class LikeServiceTest {
     @Test
     @DisplayName("unlikePost: 좋아요를 누른 적이 없는 경우카운트는 감소하지 않는다")
     void unlikePost_notLiked_doesNotDecreaseCount() {
-        User user = newUser();
-        Post post = newPost();
+        User user = user().id(USER_ID).build();
+        Post post = post().id(POST_ID).likeCount(10).viewCount(5).commentCount(3).build();
         long initialCount = post.getLikeCount();
 
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);

--- a/src/test/java/com/example/ktb3community/post/like/LikeServiceTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeServiceTest.java
@@ -1,0 +1,120 @@
+package com.example.ktb3community.post.like;
+
+import com.example.ktb3community.post.domain.Post;
+import com.example.ktb3community.post.dto.LikeResponse;
+import com.example.ktb3community.post.repository.PostLikeRepository;
+import com.example.ktb3community.post.repository.PostRepository;
+import com.example.ktb3community.post.service.LikeService;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static com.example.ktb3community.TestFixtures.POST_ID;
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class LikeServiceTest {
+
+    @Mock UserRepository userRepository;
+    @Mock PostRepository postRepository;
+    @Mock PostLikeRepository postLikeRepository;
+
+    @InjectMocks
+    LikeService likeService;
+
+
+    private User newUser() {
+        return User.builder().id(USER_ID).build();
+    }
+
+    private Post newPost() {
+        Post post = Post.builder()
+                .likeCount(10)
+                .viewCount(5)
+                .commentCount(3)
+                .build();
+        ReflectionTestUtils.setField(post, "id", POST_ID);
+        return post;
+    }
+
+    @Test
+    @DisplayName("likePost: 좋아요를 처음 누르면 카운트가 1 증가한다")
+    void likePost_added_increasesCount() {
+        User user = newUser();
+        Post post = newPost();
+        long initialCount = post.getLikeCount();
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+        given(postLikeRepository.add(post, user)).willReturn(true);
+
+        LikeResponse response = likeService.likePost(POST_ID, USER_ID);
+
+        assertThat(post.getLikeCount()).isEqualTo(initialCount + 1);
+        assertThat(response.likeCount()).isEqualTo(initialCount + 1);
+
+        verify(postLikeRepository).add(post, user);
+    }
+
+    @Test
+    @DisplayName("likePost: 이미 좋아요를 눌렀던 경우 카운트는 증가하지 않는다")
+    void likePost_alreadyLiked_doesNotIncreaseCount() {
+        User user = newUser();
+        Post post = newPost();
+        long initialCount = post.getLikeCount();
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+        given(postLikeRepository.add(post, user)).willReturn(false);
+
+        LikeResponse response = likeService.likePost(POST_ID, USER_ID);
+
+        assertThat(post.getLikeCount()).isEqualTo(initialCount);
+        assertThat(response.likeCount()).isEqualTo(initialCount);
+    }
+
+    @Test
+    @DisplayName("unlikePost: 좋아요 취소 성공 시 카운트가 1 감소한다")
+    void unlikePost_removed_decreasesCount() {
+        User user = newUser();
+        Post post = newPost();
+        long initialCount = post.getLikeCount();
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+        given(postLikeRepository.remove(post, user)).willReturn(true);
+
+        LikeResponse response = likeService.unlikePost(POST_ID, USER_ID);
+
+        assertThat(post.getLikeCount()).isEqualTo(initialCount - 1);
+        assertThat(response.likeCount()).isEqualTo(initialCount - 1);
+
+        verify(postLikeRepository).remove(post, user);
+    }
+
+    @Test
+    @DisplayName("unlikePost: 좋아요를 누른 적이 없는 경우카운트는 감소하지 않는다")
+    void unlikePost_notLiked_doesNotDecreaseCount() {
+        User user = newUser();
+        Post post = newPost();
+        long initialCount = post.getLikeCount();
+
+        given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
+        given(postRepository.findByIdOrThrow(POST_ID)).willReturn(post);
+        given(postLikeRepository.remove(post, user)).willReturn(false);
+
+        LikeResponse response = likeService.unlikePost(POST_ID, USER_ID);
+
+        assertThat(post.getLikeCount()).isEqualTo(initialCount);
+        assertThat(response.likeCount()).isEqualTo(initialCount);
+    }
+}

--- a/src/test/java/com/example/ktb3community/post/like/LikeTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeTest.java
@@ -8,23 +8,18 @@ import org.junit.jupiter.api.Test;
 
 import java.time.Instant;
 
+import static com.example.ktb3community.TestEntityFactory.like;
+import static com.example.ktb3community.TestEntityFactory.post;
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class LikeTest {
 
-    private User newUser() {
-        return User.builder().id(1L).build();
-    }
-
-    private Post newPost() {
-        return Post.builder().id(1L).build();
-    }
-
     @Test
     @DisplayName("createNew: 좋아요 생성 시 deletedAt은 null이다")
     void createNew_success() {
-        Post post = newPost();
-        User user = newUser();
+        Post post = post().id(1L).build();
+        User user = user().id(1L).build();
 
         Like like = Like.createNew(post, user);
 
@@ -37,7 +32,7 @@ class LikeTest {
     @Test
     @DisplayName("delete: 좋아요 취소 시 deletedAt이 현재 시간으로 설정된다")
     void delete_success() {
-        Like like = Like.createNew(newPost(), newUser());
+        Like like = like(post().id(1L).build(), user().id(1L).build()).build();
         Instant now = Instant.now();
 
         like.delete(now);
@@ -49,7 +44,7 @@ class LikeTest {
     @Test
     @DisplayName("delete: 이미 취소된 좋아요를 다시 취소해도 시간은 변경되지 않는다")
     void delete_idempotent() {
-        Like like = Like.createNew(newPost(), newUser());
+        Like like = like(post().id(1L).build(), user().id(1L).build()).build();
         Instant firstTime = Instant.parse("2025-01-01T10:00:00Z");
         Instant secondTime = Instant.parse("2025-01-01T12:00:00Z");
 
@@ -62,7 +57,7 @@ class LikeTest {
     @Test
     @DisplayName("restore: 삭제된 좋아요를 복구하면 deletedAt이 null이 된다")
     void restore_success() {
-        Like like = Like.createNew(newPost(), newUser());
+        Like like = like(post().id(1L).build(), user().id(1L).build()).build();
         like.delete(Instant.now());
         assertThat(like.isDeleted()).isTrue();
 
@@ -75,7 +70,7 @@ class LikeTest {
     @Test
     @DisplayName("restore: 이미 활성화된 좋아요를 복구해도 변화가 없다")
     void restore_idempotent() {
-        Like like = Like.createNew(newPost(), newUser());
+        Like like = like(post().id(1L).build(), user().id(1L).build()).build();
 
         like.restore();
 
@@ -86,7 +81,7 @@ class LikeTest {
     @Test
     @DisplayName("isDeleted: deletedAt 값 유무에 따른 상태 반환 확인")
     void isDeleted_check() {
-        Like like = Like.builder().build();
+        Like like = like(post().build(), user().build()).build();
 
         assertThat(like.isDeleted()).isFalse();
 

--- a/src/test/java/com/example/ktb3community/post/like/LikeTest.java
+++ b/src/test/java/com/example/ktb3community/post/like/LikeTest.java
@@ -1,4 +1,4 @@
-package com.example.ktb3community.post;
+package com.example.ktb3community.post.like;
 
 import com.example.ktb3community.post.domain.Like;
 import com.example.ktb3community.post.domain.Post;

--- a/src/test/java/com/example/ktb3community/s3/FileControllerTest.java
+++ b/src/test/java/com/example/ktb3community/s3/FileControllerTest.java
@@ -54,7 +54,7 @@ class FileControllerTest {
 
     @Test
     @DisplayName("[200] Presigned URL 발급 성공")
-    void presignUpload_200_default() throws Exception {
+    void presignUpload_200_defaultContentType() throws Exception {
         String fileName = "test.png";
         String defaultContentType = "image/png";
 
@@ -83,7 +83,7 @@ class FileControllerTest {
 
     @Test
     @DisplayName("[200] Presigned URL 발급 성공")
-    void presignUpload_200_explicitContentType() throws Exception {
+    void presignUpload_200_customContentType() throws Exception {
         String fileName = "test.jpg";
         String contentType = "image/jpeg";
 
@@ -114,8 +114,8 @@ class FileControllerTest {
     }
 
     @Test
-    @DisplayName("[422] 지원하지 않는 파일 형식이면 예외 발생")
-    void presignUpload_422_invalidType() throws Exception {
+    @DisplayName("[400] 지원하지 않는 파일 형식이면 예외 발생")
+    void presignUpload_400_invalidType() throws Exception {
         String fileName = "test.txt";
         String invalidType = "text/plain";
 

--- a/src/test/java/com/example/ktb3community/s3/FileControllerTest.java
+++ b/src/test/java/com/example/ktb3community/s3/FileControllerTest.java
@@ -1,0 +1,131 @@
+package com.example.ktb3community.s3;
+
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.s3.controller.FileController;
+import com.example.ktb3community.s3.dto.PresignUploadResponse;
+import com.example.ktb3community.s3.service.FileService;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(FileController.class)
+class FileControllerTest {
+
+    @Autowired MockMvc mockMvc;
+
+    @MockitoBean FileService fileService;
+
+    @BeforeEach
+    void setUp() {
+        User mockUser = User.builder()
+                .id(USER_ID)
+                .email("test@email.com")
+                .role(com.example.ktb3community.common.Role.ROLE_USER)
+                .build();
+
+        CustomUserDetails principal = CustomUserDetails.from(mockUser);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        SecurityContextHolder.setContext(context);
+    }
+
+    @Test
+    @DisplayName("[200] Presigned URL 발급 성공")
+    void presignUpload_200_default() throws Exception {
+        String fileName = "test.png";
+        String defaultContentType = "image/png";
+
+        Map<String, List<String>> headers = Map.of(
+                "Content-Type", List.of("image/jpeg"),
+                "x-amz-meta-author", List.of("tester")
+        );
+
+        PresignUploadResponse response = new PresignUploadResponse(
+                "https://s3.url/presigned",
+                "images/uuid_test.png",
+                headers
+        );
+
+        given(fileService.presignUpload(fileName, defaultContentType)).willReturn(response);
+
+        mockMvc.perform(get("/uploads/presigned-url")
+                        .param("fileName", fileName)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploadUrl").value("https://s3.url/presigned"))
+                .andExpect(jsonPath("$.data.key").value("images/uuid_test.png"));
+
+        verify(fileService).presignUpload(fileName, defaultContentType);
+    }
+
+    @Test
+    @DisplayName("[200] Presigned URL 발급 성공")
+    void presignUpload_200_explicitContentType() throws Exception {
+        String fileName = "test.jpg";
+        String contentType = "image/jpeg";
+
+        PresignUploadResponse response = new PresignUploadResponse(
+                "https://s3.url/presigned-jpg",
+                "images/uuid_test.jpg",
+                Collections.emptyMap()
+        );
+
+        given(fileService.presignUpload(fileName, contentType)).willReturn(response);
+
+        mockMvc.perform(get("/uploads/presigned-url")
+                        .param("fileName", fileName)
+                        .param("contentType", contentType))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.uploadUrl").value("https://s3.url/presigned-jpg"));
+
+        verify(fileService).presignUpload(fileName, contentType);
+    }
+
+    @Test
+    @DisplayName("[400] 파일 이름(fileName) 파라미터가 없으면 400 Bad Request")
+    void presignUpload_400_missingParam() throws Exception {
+
+        mockMvc.perform(get("/uploads/presigned-url")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("[422] 지원하지 않는 파일 형식이면 예외 발생")
+    void presignUpload_422_invalidType() throws Exception {
+        String fileName = "test.txt";
+        String invalidType = "text/plain";
+
+        given(fileService.presignUpload(fileName, invalidType))
+                .willThrow(new BusinessException(ErrorCode.CONTENT_TYPE_NOT_ALLOWED));
+
+        mockMvc.perform(get("/uploads/presigned-url")
+                        .param("fileName", fileName)
+                        .param("contentType", invalidType))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.CONTENT_TYPE_NOT_ALLOWED.getCode()));
+    }
+}

--- a/src/test/java/com/example/ktb3community/s3/FileServiceTest.java
+++ b/src/test/java/com/example/ktb3community/s3/FileServiceTest.java
@@ -1,0 +1,178 @@
+package com.example.ktb3community.s3;
+
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.s3.dto.PresignUploadResponse;
+import com.example.ktb3community.s3.service.FileService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.S3Exception;
+import software.amazon.awssdk.services.s3.presigner.S3Presigner;
+import software.amazon.awssdk.services.s3.presigner.model.PresignedPutObjectRequest;
+import software.amazon.awssdk.services.s3.presigner.model.PutObjectPresignRequest;
+
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class FileServiceTest {
+
+    @Mock S3Presigner s3Presigner;
+    @Mock S3Client s3Client;
+
+    @InjectMocks
+    FileService fileService;
+
+    private static final String BUCKET_NAME = "test-bucket";
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(fileService, "bucketName", BUCKET_NAME);
+        ReflectionTestUtils.setField(fileService, "uploadExpMinutes", 10L);
+    }
+
+
+    @Test
+    @DisplayName("presignUpload: 유효한 파일명과 타입이면 Presigned URL을 발급한다")
+    void presignUpload_success() throws MalformedURLException {
+        String fileName = "test.jpg";
+        String contentType = "image/jpeg";
+        URL mockUrl = new URL("https://s3.aws.com/test-bucket/images/uuid_test.jpg");
+
+        PresignedPutObjectRequest presignedResponse = mock(PresignedPutObjectRequest.class);
+        given(presignedResponse.url()).willReturn(mockUrl);
+        given(s3Presigner.presignPutObject(any(PutObjectPresignRequest.class))).willReturn(presignedResponse);
+
+        PresignUploadResponse response = fileService.presignUpload(fileName, contentType);
+
+        assertThat(response.uploadUrl()).isEqualTo(mockUrl.toString());
+        assertThat(response.key()).startsWith("images/");
+        assertThat(response.key()).endsWith("_" + fileName);
+    }
+
+    @Test
+    @DisplayName("presignUpload: 지원하지 않는 Content-Type이면 예외 발생")
+    void presignUpload_invalidType_throws() {
+        String fileName = "test.txt";
+        String contentType = "text/plain";
+
+        assertThatThrownBy(() -> fileService.presignUpload(fileName, contentType))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.CONTENT_TYPE_NOT_ALLOWED);
+    }
+
+    @Test
+    @DisplayName("presignUpload: 파일명이 비어있으면 예외 발생")
+    void presignUpload_blankName_throws() {
+        String fileName = "   ";
+        assertThatThrownBy(() -> fileService.presignUpload(fileName, "image/png"))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.FILE_NAME_IS_NOT_BLANK);
+    }
+
+    @Test
+    @DisplayName("deleteImageIfChanged: 이미지가 변경되었으면 기존 이미지를 삭제한다")
+    void deleteImageIfChanged_success() {
+        String oldUrl = "https://bucket.s3.com/images/old.jpg";
+        String newUrl = "https://bucket.s3.com/images/new.jpg";
+
+        fileService.deleteImageIfChanged(oldUrl, newUrl);
+        verify(s3Client).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("deleteImageIfChanged: 기존 이미지가 없거나(null/blank) 변경되지 않았으면 삭제하지 않는다")
+    void deleteImageIfChanged_skip() {
+        fileService.deleteImageIfChanged(null, "new.jpg");
+        verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+
+        fileService.deleteImageIfChanged("same.jpg", "same.jpg");
+        verify(s3Client, never()).deleteObject(any(DeleteObjectRequest.class));
+    }
+
+    @Test
+    @DisplayName("deleteImage: 전체 URL에서 Key를 추출하여 S3 삭제를 요청한다")
+    void deleteImage_fullUrl_success() {
+        String expectedKey = "images/test-uuid_image.jpg";
+        String fullUrl = "https://" + BUCKET_NAME + ".s3.ap-northeast-2.amazonaws.com/" + expectedKey;
+
+        fileService.deleteImage(fullUrl);
+
+        ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(captor.capture());
+
+        DeleteObjectRequest request = captor.getValue();
+        assertThat(request.bucket()).isEqualTo(BUCKET_NAME);
+        assertThat(request.key()).isEqualTo(expectedKey);
+    }
+
+    @Test
+    @DisplayName("deleteImage: 상대 경로(/images/...)가 입력되어도 삭제 가능하다")
+    void deleteImage_relativePath_success() {
+        String relativePath = "/images/test.jpg";
+
+        fileService.deleteImage(relativePath);
+
+        ArgumentCaptor<DeleteObjectRequest> captor = ArgumentCaptor.forClass(DeleteObjectRequest.class);
+        verify(s3Client).deleteObject(captor.capture());
+        assertThat(captor.getValue().key()).isEqualTo("images/test.jpg");
+    }
+
+    @Test
+    @DisplayName("deleteImage: 'images/'로 시작하지 않는 Key는 예외 발생 (잘못된 경로)")
+    void deleteImage_invalidKey_throws() {
+        String invalidUrl = "https://s3.com/bucket/files/test.jpg";
+
+        Throwable thrown = catchThrowable(() ->  fileService.deleteImage(invalidUrl));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_S3_KEY);
+    }
+
+    @Test
+    @DisplayName("deleteImage: URL 형식이 잘못되면 예외 발생")
+    void deleteImage_malformedUrl_throws() {
+        String badUrl = "http://bad url with spaces";
+
+        Throwable thrown = catchThrowable(() ->  fileService.deleteImage(badUrl));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_IMG_URL);
+    }
+
+    @Test
+    @DisplayName("deleteImage: S3 클라이언트 에러 발생 시 BusinessException으로 래핑한다")
+    void deleteImage_s3Exception_throws() {
+        String url = "https://bucket.com/images/valid.jpg";
+
+        doThrow(S3Exception.builder().message("AWS Error").build())
+                .when(s3Client).deleteObject(any(DeleteObjectRequest.class));
+
+        Throwable thrown = catchThrowable(() ->  fileService.deleteImage(url));
+
+        assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.S3_DELETE_FAILED);
+    }
+}

--- a/src/test/java/com/example/ktb3community/user/JpaUserRepositoryTest.java
+++ b/src/test/java/com/example/ktb3community/user/JpaUserRepositoryTest.java
@@ -1,0 +1,65 @@
+package com.example.ktb3community.user;
+
+import com.example.ktb3community.common.Role;
+import com.example.ktb3community.config.JpaConfig;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.repository.JpaUserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+
+import java.time.Instant;
+import java.util.Optional;
+
+import static com.example.ktb3community.TestEntityFactory.user;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+@DataJpaTest
+@Import(JpaConfig.class)
+class JpaUserRepositoryTest {
+    @Autowired
+    private JpaUserRepository jpaUserRepository;
+    @Test
+    @DisplayName("soft_delete된 유저는 조회 메서드에서 검색되지 않아야 한다.")
+    void findByEmailAndDeletedAtIsNull() {
+        User deletedUser = user()
+                .id(null)
+                .email("user@test.com")
+                .passwordHash("hash")
+                .nickname("deletedUser")
+                .profileImageUrl("http://image")
+                .role(Role.ROLE_USER)
+                .build();
+
+        jpaUserRepository.save(deletedUser);
+        jpaUserRepository.softDeleteById(deletedUser.getId(), java.time.Instant.now());
+
+        Optional<User> result = jpaUserRepository.findByEmailAndDeletedAtIsNull("user@test.com");
+        assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("softDeleteById에서 deletedAt, updatedAt이 갱신된다")
+    void softDeleteById_updates_deletedAt() {
+
+        User user = user()
+                .id(null)
+                .email("user@test.com")
+                .passwordHash("hash")
+                .nickname("deletedUser")
+                .profileImageUrl("http://image")
+                .role(Role.ROLE_USER)
+                .build();
+        User savedUser = jpaUserRepository.save(user);
+
+        int updatedCount = jpaUserRepository.softDeleteById(savedUser.getId(), Instant.now());
+
+        assertThat(updatedCount).isEqualTo(1);
+
+        User updatedUser = jpaUserRepository.findById(savedUser.getId()).orElseThrow();
+        assertThat(updatedUser.getDeletedAt()).isNotNull();
+        assertThat(updatedUser.getUpdatedAt()).isAfter(savedUser.getCreatedAt());
+    }
+}

--- a/src/test/java/com/example/ktb3community/user/UserControllerTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserControllerTest.java
@@ -1,0 +1,55 @@
+package com.example.ktb3community.user;
+import com.example.ktb3community.user.controller.UserController;
+import com.example.ktb3community.user.dto.UpdateMeRequest;
+import com.example.ktb3community.user.service.UserService;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(UserController.class)
+class UserControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private UserService userService;
+
+    @Test
+    @DisplayName("getAvailability에서 이메일과 닉네임 파라미터가 모두 없으면 400 에러가 터져야 한다")
+    void getAvailability_missingBothParams_throws() throws Exception {
+        mockMvc.perform(get("/users/availability")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andDo(print())
+                .andExpect(status().is4xxClientError());
+    }
+
+    @Test
+    @DisplayName("updateMe에서 닉네임 형식이 맞지 않으면 422 에러가 터져야 한다")
+    @WithMockUser
+    void updateMe_validationNickname_throws() throws Exception {
+        UpdateMeRequest invalidRequest = new UpdateMeRequest("invalid nickname", "https://img.url");
+
+        mockMvc.perform(patch("/users/me")
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isUnprocessableEntity());
+    }
+}

--- a/src/test/java/com/example/ktb3community/user/UserControllerTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserControllerTest.java
@@ -1,21 +1,38 @@
 package com.example.ktb3community.user;
+
+import com.example.ktb3community.auth.security.CustomUserDetails;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
 import com.example.ktb3community.user.controller.UserController;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.dto.AvailabilityResponse;
+import com.example.ktb3community.user.dto.MeResponse;
 import com.example.ktb3community.user.dto.UpdateMeRequest;
+import com.example.ktb3community.user.dto.UpdatePasswordRequest;
 import com.example.ktb3community.user.service.UserService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.http.MediaType;
-import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
+import static com.example.ktb3community.TestFixtures.USER_ID;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @WebMvcTest(UserController.class)
@@ -30,26 +47,174 @@ class UserControllerTest {
     @MockitoBean
     private UserService userService;
 
-    @Test
-    @DisplayName("getAvailability에서 이메일과 닉네임 파라미터가 모두 없으면 400 에러가 터져야 한다")
-    void getAvailability_missingBothParams_throws() throws Exception {
-        mockMvc.perform(get("/users/availability")
-                        .contentType(MediaType.APPLICATION_JSON))
-                .andDo(print())
-                .andExpect(status().is4xxClientError());
+    @BeforeEach
+    void setUp() {
+        User mockUser = User.builder()
+                .id(USER_ID)
+                .email("test@email.com")
+                .passwordHash("encoded")
+                .nickname("test")
+                .role(com.example.ktb3community.common.Role.ROLE_USER)
+                .build();
+
+        CustomUserDetails principal = CustomUserDetails.from(mockUser);
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(new UsernamePasswordAuthenticationToken(principal, null, principal.getAuthorities()));
+        SecurityContextHolder.setContext(context);
     }
 
     @Test
-    @DisplayName("updateMe에서 닉네임 형식이 맞지 않으면 422 에러가 터져야 한다")
-    @WithMockUser
-    void updateMe_validationNickname_throws() throws Exception {
-        UpdateMeRequest invalidRequest = new UpdateMeRequest("invalid nickname", "https://img.url");
+    @DisplayName("[200] 중복 확인 성공")
+    void getAvailability_200() throws Exception {
+        AvailabilityResponse response = new AvailabilityResponse(true, true);
+        given(userService.getAvailability("email", null)).willReturn(response);
 
-        mockMvc.perform(patch("/users/me")
-                        .content(objectMapper.writeValueAsString(invalidRequest))
-                        .contentType(MediaType.APPLICATION_JSON)
+        mockMvc.perform(get("/users/availability")
+                        .param("email", "email")
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.emailAvailable").value(true));
+    }
+
+    @Test
+    @DisplayName("[400] 파라미터가 둘 다 없으면 Bad Request")
+    void getAvailability_400_missingParams() throws Exception {
+
+        mockMvc.perform(get("/users/availability")
                         .with(csrf()))
                 .andDo(print())
-                .andExpect(status().isUnprocessableEntity());
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(ErrorCode.MISSING_PARAMETER.getCode()));
+    }
+
+    @Test
+    @DisplayName("[500] 서버 내부 에러 발생")
+    void getAvailability_500() throws Exception {
+        given(userService.getAvailability(any(), any()))
+                .willThrow(new RuntimeException("Unexpected error"));
+
+        mockMvc.perform(get("/users/availability")
+                        .param("email", "test")
+                        .with(csrf()))
+                .andExpect(status().isInternalServerError())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INTERNAL_SERVER_ERROR.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 내 정보 조회 성공")
+    void getMe_200() throws Exception {
+        MeResponse response = new MeResponse("email", "nick", "img");
+        given(userService.getMe(USER_ID)).willReturn(response);
+
+        mockMvc.perform(get("/users/me").with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("nick"));
+    }
+
+    @Test
+    @DisplayName("[401] 인증 정보가 없으면 Unauthorized")
+    void getMe_401() throws Exception {
+        SecurityContextHolder.clearContext();
+
+        mockMvc.perform(get("/users/me").with(csrf()))
+                .andExpect(status().isUnauthorized());
+    }
+
+    @Test
+    @DisplayName("[404] 존재하지 않는 유저 조회 시 404 Not Found")
+    void getMe_404() throws Exception {
+        given(userService.getMe(USER_ID))
+                .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        mockMvc.perform(get("/users/me").with(csrf()))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(ErrorCode.USER_NOT_FOUND.getCode()));
+    }
+
+    @Test
+    @DisplayName("[204] 내 비밀번호 수정 성공")
+    void updatePassword_204() throws Exception {
+        UpdatePasswordRequest request = new UpdatePasswordRequest("NewPassword1234!");
+
+        mockMvc.perform(post("/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("[422] @Valid 검증 실패 시 422")
+    void updatePassword_422_validation() throws Exception {
+        UpdatePasswordRequest invalidRequest = new UpdatePasswordRequest( "newPassword");
+
+        mockMvc.perform(post("/users/me/password")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[200] 내 정보 수정 성공")
+    void updateMe_200() throws Exception {
+        UpdateMeRequest request = new UpdateMeRequest("newNick", "newImg");
+        MeResponse response = new MeResponse("email", "newNick", "newImg");
+
+        given(userService.updateMe(eq(USER_ID), any(UpdateMeRequest.class)))
+                .willReturn(response);
+
+        mockMvc.perform(patch("/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.nickname").value("newNick"));
+    }
+
+    @Test
+    @DisplayName("[422] @Valid 검증 실패 시 422")
+    void updateMe_422_validation() throws Exception {
+        UpdateMeRequest invalidRequest = new UpdateMeRequest("", "");
+
+        mockMvc.perform(patch("/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(invalidRequest))
+                        .with(csrf()))
+                .andDo(print())
+                .andExpect(status().isUnprocessableEntity())
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_INPUT_VALUE.getCode()));
+    }
+
+    @Test
+    @DisplayName("[400] JSON 형식이 잘못된 경우 -> 400 Bad Request")
+    void updateMe_400_badJson() throws Exception {
+        String brokenJson = "{ \"nickname\": \"test\", }";
+
+        mockMvc.perform(patch("/users/me")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(brokenJson)
+                        .with(csrf()))
+                .andExpect(status().isBadRequest()) // 400 확인
+                .andExpect(jsonPath("$.code").value(ErrorCode.INVALID_REQUEST_BODY.getCode()));
+    }
+    @Test
+    @DisplayName("[204] 회원 탈퇴 성공")
+    void withdrawMe_204() throws Exception {
+        mockMvc.perform(delete("/users/me").with(csrf()))
+                .andExpect(status().isNoContent());
+    }
+
+    @Test
+    @DisplayName("[403] 서비스에서 접근 거부 예외 발생 시 403 Forbidden")
+    void withdrawMe_403() throws Exception {
+        doThrow(new AccessDeniedException("No permission"))
+                .when(userService).withdrawMe(eq(USER_ID), any());
+
+        mockMvc.perform(delete("/users/me").with(csrf()))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.code").value(ErrorCode.AUTH_FORBIDDEN.getCode()));
     }
 }

--- a/src/test/java/com/example/ktb3community/user/UserControllerTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserControllerTest.java
@@ -65,7 +65,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[200] 중복 확인 성공")
-    void getAvailability_200() throws Exception {
+    void getAvailability_200_success() throws Exception {
         AvailabilityResponse response = new AvailabilityResponse(true, true);
         given(userService.getAvailability("email", null)).willReturn(response);
 
@@ -89,7 +89,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[500] 서버 내부 에러 발생")
-    void getAvailability_500() throws Exception {
+    void getAvailability_500_internalError() throws Exception {
         given(userService.getAvailability(any(), any()))
                 .willThrow(new RuntimeException("Unexpected error"));
 
@@ -102,7 +102,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[200] 내 정보 조회 성공")
-    void getMe_200() throws Exception {
+    void getMe_200_success() throws Exception {
         MeResponse response = new MeResponse("email", "nick", "img");
         given(userService.getMe(USER_ID)).willReturn(response);
 
@@ -113,7 +113,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[401] 인증 정보가 없으면 Unauthorized")
-    void getMe_401() throws Exception {
+    void getMe_401_unauthenticated() throws Exception {
         SecurityContextHolder.clearContext();
 
         mockMvc.perform(get("/users/me").with(csrf()))
@@ -122,7 +122,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[404] 존재하지 않는 유저 조회 시 404 Not Found")
-    void getMe_404() throws Exception {
+    void getMe_404_notFound() throws Exception {
         given(userService.getMe(USER_ID))
                 .willThrow(new BusinessException(ErrorCode.USER_NOT_FOUND));
 
@@ -133,7 +133,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[204] 내 비밀번호 수정 성공")
-    void updatePassword_204() throws Exception {
+    void updatePassword_204_success() throws Exception {
         UpdatePasswordRequest request = new UpdatePasswordRequest("NewPassword1234!");
 
         mockMvc.perform(post("/users/me/password")
@@ -159,7 +159,7 @@ class UserControllerTest {
 
     @Test
     @DisplayName("[200] 내 정보 수정 성공")
-    void updateMe_200() throws Exception {
+    void updateMe_200_success() throws Exception {
         UpdateMeRequest request = new UpdateMeRequest("newNick", "newImg");
         MeResponse response = new MeResponse("email", "newNick", "newImg");
 
@@ -202,14 +202,14 @@ class UserControllerTest {
     }
     @Test
     @DisplayName("[204] 회원 탈퇴 성공")
-    void withdrawMe_204() throws Exception {
+    void withdrawMe_204_success() throws Exception {
         mockMvc.perform(delete("/users/me").with(csrf()))
                 .andExpect(status().isNoContent());
     }
 
     @Test
     @DisplayName("[403] 서비스에서 접근 거부 예외 발생 시 403 Forbidden")
-    void withdrawMe_403() throws Exception {
+    void withdrawMe_403_forbidden() throws Exception {
         doThrow(new AccessDeniedException("No permission"))
                 .when(userService).withdrawMe(eq(USER_ID), any());
 

--- a/src/test/java/com/example/ktb3community/user/UserServiceTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserServiceTest.java
@@ -32,6 +32,7 @@ import java.time.Instant;
 import static com.example.ktb3community.TestFixtures.USER_ID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 import static org.mockito.Mockito.*;
@@ -165,9 +166,13 @@ class UserServiceTest {
         given(userRepository.findByIdOrThrow(USER_ID)).willReturn(user);
         given(userRepository.existsByNickname("existingNick")).willReturn(true);
 
-        assertThatThrownBy(() -> userService.updateMe(USER_ID, request))
+
+        Throwable thrown = catchThrowable(() -> userService.updateMe(USER_ID, request));
+
+        assertThat(thrown)
                 .isInstanceOf(BusinessException.class)
-                .hasFieldOrPropertyWithValue("errorCode", ErrorCode.NICKNAME_ALREADY_EXIST);
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.NICKNAME_ALREADY_EXIST);
 
         assertThat(user.getNickname()).isEqualTo("oldNick");
     }

--- a/src/test/java/com/example/ktb3community/user/UserServiceTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserServiceTest.java
@@ -1,0 +1,230 @@
+package com.example.ktb3community.user;
+
+import com.example.ktb3community.auth.service.RefreshTokenService;
+import com.example.ktb3community.comment.repository.CommentRepository;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.post.repository.PostRepository;
+import com.example.ktb3community.s3.service.FileService;
+import com.example.ktb3community.user.domain.User;
+import com.example.ktb3community.user.dto.AvailabilityResponse;
+import com.example.ktb3community.user.dto.MeResponse;
+import com.example.ktb3community.user.dto.UpdateMeRequest;
+import com.example.ktb3community.user.dto.UpdatePasswordRequest;
+import com.example.ktb3community.user.mapper.UserMapper;
+import com.example.ktb3community.user.repository.UserRepository;
+import com.example.ktb3community.user.service.UserService;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+    @Mock
+    UserRepository userRepository;
+
+    @Mock
+    PostRepository postRepository;
+
+    @Mock
+    CommentRepository commentRepository;
+
+    @Mock
+    UserMapper userMapper;
+
+    @Mock
+    FileService fileService;
+
+    @Mock
+    PasswordEncoder passwordEncoder;
+
+    @Mock
+    RefreshTokenService refreshTokenService;
+
+    @InjectMocks
+    UserService userService;
+
+    @Test
+    @DisplayName("getAvailability는 입력값을 trim하여 email/nickname 중복 여부를 조회한다")
+    void getAvailability_success() {
+        when(userRepository.existsByEmail("user@test.com")).thenReturn(false);
+        when(userRepository.existsByNickname("nick")).thenReturn(true);
+
+        AvailabilityResponse response = userService.getAvailability("  USER@test.com  ", "  nick  ");
+
+        assertTrue(response.emailAvailable());
+        assertFalse(response.nicknameAvailable());
+
+        // 호출 검증
+        verify(userRepository).existsByEmail("user@test.com");
+        verify(userRepository).existsByNickname("nick");
+    }
+
+    @ParameterizedTest
+    @DisplayName("getAvailability는 값이 없거나 공백이면 null을 반환한다")
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t", "\n"})
+    void getAvailability_nullOrBlank(String invalid) {
+
+        AvailabilityResponse response = userService.getAvailability(invalid, invalid);
+
+        assertNull(response.emailAvailable());
+        assertNull(response.nicknameAvailable());
+
+        verifyNoInteractions(userRepository);
+    }
+
+    @Test
+    @DisplayName("updateMe는 닉네임이 변경될 경우 중복을 확인 후 변경하고, 프로필 이미지 변경 여부에 따라 파일 정리를 요청한다")
+    void updateMe_nicknameChanged_profileImageChanged_success() {
+        Long userId = 1L;
+        UpdateMeRequest request = new UpdateMeRequest("newNick", "newImage");
+        User user = mock(User.class);
+
+        when(user.getNickname()).thenReturn("oldNick");
+        when(user.getProfileImageUrl()).thenReturn("oldImage");
+
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+        when(userRepository.existsByNickname("newNick")).thenReturn(false);
+
+        MeResponse meResponse = new MeResponse("user@test.com", "newNick", "newImage");
+        when(userMapper.userToMeResponse(user)).thenReturn(meResponse);
+
+        MeResponse result = userService.updateMe(userId, request);
+
+        verify(userRepository).findByIdOrThrow(userId);
+        verify(userRepository).existsByNickname("newNick");
+        verify(user).updateProfileImageUrl("newImage");
+        verify(fileService).deleteImageIfChanged("oldImage", "newImage");
+        verify(userMapper).userToMeResponse(user);
+
+        assertSame(meResponse, result);
+    }
+
+    @Test
+    @DisplayName("updateMe는 다른 사용자가 이미 사용 중인 닉네임으로 변경하려 하면 예외를 던진다")
+    void updateMe_nicknameDuplicate_throws() {
+        Long userId = 1L;
+        UpdateMeRequest request = new UpdateMeRequest("existingNick", null);
+        User user = mock(User.class);
+
+        when(user.getNickname()).thenReturn("oldNick");
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+        when(userRepository.existsByNickname("existingNick")).thenReturn(true);
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> userService.updateMe(userId, request)
+        );
+
+        assertEquals(ErrorCode.NICKNAME_ALREADY_EXIST, ex.getErrorCode());
+
+        verify(userRepository).findByIdOrThrow(userId);
+        verify(userRepository).existsByNickname("existingNick");
+        verifyNoMoreInteractions(user);
+        verifyNoInteractions(fileService);
+        verifyNoInteractions(userMapper);
+    }
+
+    @ParameterizedTest
+    @DisplayName("updateMe는 닉네임/프로필 이미지가 null 또는 공백일 때 닉네임/프로필 관련 로직을 건너뛴다")
+    @NullAndEmptySource
+    @ValueSource(strings = {"  ", "\t", "\n"})
+    void updateMe_whenNullOrBlank_skip(String invalid) {
+        Long userId = 1L;
+
+        UpdateMeRequest request = new UpdateMeRequest(invalid, invalid);
+
+        User user = mock(User.class);
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+
+
+        userService.updateMe(userId, request);
+
+        verify(userRepository).findByIdOrThrow(userId);
+        verifyNoMoreInteractions(user);
+        verifyNoInteractions(fileService);
+    }
+
+    @Test
+    @DisplayName("updateMe는 닉네임이 현재 닉네임과 동일할 때 닉네임 관련 로직을 건너뛴다")
+    void updateMe_whenNicknameSameAsCurrent_skip() {
+        Long userId = 1L;
+
+        UpdateMeRequest req = new UpdateMeRequest("sameNick", null);
+
+        User user = mock(User.class);
+        when(user.getNickname()).thenReturn("sameNick");
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+
+        userService.updateMe(userId, req);
+
+        verify(userRepository, never()).existsByNickname(any());
+        verify(user, never()).updateNickname(any());
+    }
+
+    @Test
+    @DisplayName("updateMe는 중복된 닉네임으로 변경하려 할 때 예외를 던진다")
+    void updateMe_whenNicknameDuplicate_throws() {
+        Long userId = 1L;
+
+        UpdateMeRequest req = new UpdateMeRequest("dupNick", null);
+
+        User user = mock(User.class);
+        when(user.getNickname()).thenReturn("oldNick");
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+        when(userRepository.existsByNickname("dupNick")).thenReturn(true);
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> userService.updateMe(userId, req)
+        );
+        assertEquals(ErrorCode.NICKNAME_ALREADY_EXIST, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("updatePassword는 비밀번호를 해시화하여 변경한다")
+    void updatePassword_success() {
+        Long userId = 1L;
+        UpdatePasswordRequest request = new UpdatePasswordRequest("newPassword");
+
+        User user = mock(User.class);
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+        when(passwordEncoder.encode("newPassword")).thenReturn("hashedPassword");
+
+        userService.updatePassword(userId, request);
+
+        verify(userRepository).findByIdOrThrow(userId);
+        verify(passwordEncoder).encode("newPassword");
+        verify(user).updatePasswordHash("hashedPassword");
+    }
+
+    @Test
+    @DisplayName("withdrawMe는 회원 탈퇴 시 관련 데이터를 모두 소프트 삭제하고 리프레시 토큰을 폐기한다")
+    void withdrawMe_success() {
+        Long userId = 1L;
+        User user = mock(User.class);
+        HttpServletResponse response = mock(HttpServletResponse.class);
+
+        when(userRepository.findByIdOrThrow(userId)).thenReturn(user);
+
+        userService.withdrawMe(userId, response);
+
+        verify(userRepository).findByIdOrThrow(userId);
+        verify(commentRepository).softDeleteByUserId(eq(userId), any());
+        verify(postRepository).softDeleteByUserId(eq(userId), any());
+        verify(userRepository).softDeleteById(eq(userId), any());
+        verify(refreshTokenService).revokeAllByUser(user);
+    }
+}

--- a/src/test/java/com/example/ktb3community/user/UserTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserTest.java
@@ -186,7 +186,7 @@ class UserTest {
     }
 
     @Test
-    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다(각각 다른 인스턴스)")
+    @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다")
     void equals_nullId_isNotEqual() {
         User user1 = newUser();
         User user2 = newUser();

--- a/src/test/java/com/example/ktb3community/user/UserTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserTest.java
@@ -25,12 +25,12 @@ class UserTest {
     }
 
     @Test
-    @DisplayName("createNew는 email/nickname/profile을 trim하고 email은 소문자로 변환한다")
-    void createNew_normalizesFields() {
-        String email = "TEST@Email.Com";
+    @DisplayName("createNew는 email/nickname/profileUrl을 trim하고 email은 소문자로 변환한다")
+    void createNew_success() {
+        String email = "  TEST@Email.Com  ";
         String passwordHash = "hash";
-        String nickname = "Nick";
-        String profileImageUrl = "http://image";
+        String nickname = "  Nick  ";
+        String profileImageUrl = "  http://image  ";
 
         User user = User.createNew(email, passwordHash, nickname, profileImageUrl, Role.ROLE_USER);
 

--- a/src/test/java/com/example/ktb3community/user/UserTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserTest.java
@@ -1,0 +1,158 @@
+package com.example.ktb3community.user;
+
+import com.example.ktb3community.common.Role;
+import com.example.ktb3community.common.constants.ValidationConstant;
+import com.example.ktb3community.common.error.ErrorCode;
+import com.example.ktb3community.exception.BusinessException;
+import com.example.ktb3community.user.domain.User;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class UserTest {
+
+    private User newUser() {
+        return User.createNew(
+                "user@test.com",
+                "hash",
+                "nickname",
+                "http://image",
+                Role.ROLE_USER
+        );
+    }
+
+    @Test
+    @DisplayName("createNew는 email/nickname/profile을 trim하고 email은 소문자로 변환한다")
+    void createNew_normalizesFields() {
+        String email = "TEST@Email.Com";
+        String passwordHash = "hash";
+        String nickname = "Nick";
+        String profileImageUrl = "http://image";
+
+        User user = User.createNew(email, passwordHash, nickname, profileImageUrl, Role.ROLE_USER);
+
+        assertNull(user.getId());
+        assertEquals("test@email.com", user.getEmail());
+        assertEquals("Nick", user.getNickname());
+        assertEquals("http://image", user.getProfileImageUrl());
+        assertEquals(passwordHash, user.getPasswordHash());
+        assertEquals(Role.ROLE_USER, user.getRole());
+        assertNull(user.getDeletedAt());
+    }
+
+    @Test
+    @DisplayName("닉네임을 정상적으로 수정하면 trim 후 값이 변경된다")
+    void updateNickname_success() {
+        User user = newUser();
+
+        user.updateNickname("  newNick  ");
+
+        assertEquals("newNick", user.getNickname());
+    }
+
+    @Test
+    @DisplayName("닉네임이 공백만 있으면 BusinessException이 발생한다")
+    void updateNickname_blank_throws() {
+        User user = newUser();
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> user.updateNickname("   ")
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("닉네임이 최대 길이를 초과하면 BusinessException이 발생한다")
+    void updateNickname_tooLong_throws() {
+        User user = newUser();
+        String tooLong = "a".repeat(ValidationConstant.NICKNAME_MAX_LENGTH + 1);
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> user.updateNickname(tooLong)
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("닉네임에 공백 문자가 포함되면 BusinessException이 발생한다")
+    void updateNickname_containsWhitespace_throws() {
+        User user = newUser();
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> user.updateNickname("new Nick")
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 URL을 정상적으로 수정하면 trim 후 값이 변경된다")
+    void updateProfileImageUrl_success() {
+        User user = newUser();
+
+        user.updateProfileImageUrl("  http://new-image  ");
+
+        assertEquals("http://new-image", user.getProfileImageUrl());
+    }
+
+    @Test
+    @DisplayName("프로필 이미지 URL이 공백만 있으면 BusinessException이 발생한다")
+    void updateProfileImageUrl_blank_throws() {
+        User user = newUser();
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> user.updateProfileImageUrl("   ")
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("암호화된 비밀번호 정상적으로 수정하면 값이 변경된다")
+    void updatePasswordHash_success() {
+        User user = newUser();
+
+        user.updatePasswordHash("passwordHashNew");
+
+        assertEquals("passwordHashNew", user.getPasswordHash());
+    }
+
+    @Test
+    @DisplayName("암호화된 비밀번호가 공백만 있으면 BusinessException이 발생한다")
+    void updatePasswordHash_blank_throws() {
+        User user = newUser();
+
+        BusinessException ex = assertThrows(
+                BusinessException.class,
+                () -> user.updatePasswordHash("   ")
+        );
+
+        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+    }
+
+    @Test
+    @DisplayName("delete는 deletedAt이 null일 때만 세팅하고, 이미 값이 있으면 변경하지 않는다")
+    void delete_setsDeletedAtOnlyOnce() {
+        User user = newUser();
+        Instant first = Instant.parse("2025-01-01T00:00:00Z");
+        Instant second = Instant.parse("2025-02-01T00:00:00Z");
+
+        user.delete(first);
+        Instant afterFirst = user.getDeletedAt();
+
+        user.delete(second);
+        Instant afterSecond = user.getDeletedAt();
+
+        assertEquals(first, afterFirst);
+        assertEquals(first, afterSecond);
+    }
+}

--- a/src/test/java/com/example/ktb3community/user/UserTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserTest.java
@@ -12,21 +12,12 @@ import org.springframework.test.util.ReflectionTestUtils;
 
 import java.time.Instant;
 
+import static com.example.ktb3community.TestEntityFactory.user;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.*;
 
 class UserTest {
-
-    private User newUser() {
-        return User.builder()
-                .email("user@test.com")
-                .passwordHash("hash")
-                .nickname("nickname")
-                .profileImageUrl("http://image")
-                .role(Role.ROLE_USER)
-                .build();
-    }
 
     @Test
     @DisplayName("createNew: 입력값을 trim하고 email은 소문자로 변환하여 생성한다")
@@ -50,7 +41,7 @@ class UserTest {
     @Test
     @DisplayName("updateNickname: 정상적인 닉네임으로 변경 시 trim되어 반영된다")
     void updateNickname_success() {
-        User user = newUser();
+        User user = user().build();
 
         user.updateNickname("  newNick  ");
 
@@ -60,7 +51,7 @@ class UserTest {
     @Test
     @DisplayName("updateNickname: 공백만 있는 경우 예외가 발생한다")
     void updateNickname_blank_throws() {
-        User user = newUser();
+        User user = user().build();
 
         BusinessException ex = assertThrows(
                 BusinessException.class,
@@ -73,7 +64,7 @@ class UserTest {
     @Test
     @DisplayName("updateNickname: 길이 초과 시 예외가 발생한다")
     void updateNickname_tooLong_throws() {
-        User user = newUser();
+        User user = user().build();
         String tooLong = "a".repeat(ValidationConstant.NICKNAME_MAX_LENGTH + 1);
 
         BusinessException ex = assertThrows(
@@ -87,7 +78,7 @@ class UserTest {
     @Test
     @DisplayName("updateNickname: 공백 포함 시 예외가 발생한다")
     void updateNickname_containsWhitespace_throws() {
-        User user = newUser();
+        User user = user().build();
 
         BusinessException ex = assertThrows(
                 BusinessException.class,
@@ -100,7 +91,7 @@ class UserTest {
     @Test
     @DisplayName("updateProfileImageUrl: 정상 변경 시 trim되어 반영된다")
     void updateProfileImageUrl_success() {
-        User user = newUser();
+        User user = user().build();
 
         user.updateProfileImageUrl("  http://new-image  ");
 
@@ -110,7 +101,7 @@ class UserTest {
     @Test
     @DisplayName("updateProfileImageUrl: 공백일 경우 예외가 발생한다")
     void updateProfileImageUrl_blank_throws() {
-        User user = newUser();
+        User user = user().build();
 
         Throwable thrown = catchThrowable(() -> user.updateProfileImageUrl("   "));
 
@@ -123,7 +114,7 @@ class UserTest {
     @Test
     @DisplayName("updatePasswordHash: 정상 변경 확인")
     void updatePasswordHash_success() {
-        User user = newUser();
+        User user = user().build();
 
         user.updatePasswordHash("passwordHashNew");
 
@@ -133,7 +124,7 @@ class UserTest {
     @Test
     @DisplayName("updatePasswordHash: 암호화된 비밀번호가 공백일 경우 예외가 발생한다")
     void updatePasswordHash_blank_throws() {
-        User user = newUser();
+        User user = user().build();
 
         BusinessException ex = assertThrows(
                 BusinessException.class,
@@ -146,7 +137,7 @@ class UserTest {
     @Test
     @DisplayName("delete: 탈퇴 시 deletedAt이 설정되며, 중복 호출되어도 시간은 변경되지 않는다")
     void delete_setsDeletedAtOnlyOnce() {
-        User user = newUser();
+        User user = user().build();
         Instant first = Instant.parse("2025-01-01T00:00:00Z");
         Instant second = Instant.parse("2025-02-01T00:00:00Z");
 
@@ -163,10 +154,10 @@ class UserTest {
     @Test
     @DisplayName("equals & hashCode: ID가 같은 두 객체는 동등하다")
     void equals_sameId_isEqual() {
-        User user1 = newUser();
+        User user1 = user().build();
         ReflectionTestUtils.setField(user1, "id", 1L);
 
-        User user2 = newUser();
+        User user2 = user().build();
         ReflectionTestUtils.setField(user2, "id", 1L);
 
         assertThat(user1).isEqualTo(user2);
@@ -176,10 +167,10 @@ class UserTest {
     @Test
     @DisplayName("equals: ID가 다르면 다른 객체다")
     void equals_differentId_isNotEqual() {
-        User user1 = newUser();
+        User user1 = user().build();
         ReflectionTestUtils.setField(user1, "id", 1L);
 
-        User user2 = newUser();
+        User user2 = user().build();
         ReflectionTestUtils.setField(user2, "id", 2L);
 
         assertThat(user1).isNotEqualTo(user2);
@@ -188,8 +179,8 @@ class UserTest {
     @Test
     @DisplayName("equals: ID가 null인 비영속 객체는 필드 값이 같아도 동등하지 않다")
     void equals_nullId_isNotEqual() {
-        User user1 = newUser();
-        User user2 = newUser();
+        User user1 = user().id(null).build();
+        User user2 = user().id(null).build();
 
         assertThat(user1).isNotEqualTo(user2);
     }
@@ -197,7 +188,7 @@ class UserTest {
     @Test
     @DisplayName("equals: 자기 자신과는 항상 동등하다")
     void equals_self_isEqual() {
-        User user = newUser();
+        User user = user().build();
         ReflectionTestUtils.setField(user, "id", 1L);
 
         assertThat(user).isEqualTo(user);
@@ -206,7 +197,7 @@ class UserTest {
     @Test
     @DisplayName("equals: 프록시 객체와 비교해도 ID가 같으면 동등하다")
     void equals_proxy_isEqual() {
-        User original = newUser();
+        User original = user().build();
         ReflectionTestUtils.setField(original, "id", 1L);
 
         User proxy = new User() {

--- a/src/test/java/com/example/ktb3community/user/UserTest.java
+++ b/src/test/java/com/example/ktb3community/user/UserTest.java
@@ -5,6 +5,7 @@ import com.example.ktb3community.common.constants.ValidationConstant;
 import com.example.ktb3community.common.error.ErrorCode;
 import com.example.ktb3community.exception.BusinessException;
 import com.example.ktb3community.user.domain.User;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -12,6 +13,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.time.Instant;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.AssertionsForClassTypes.catchThrowable;
 import static org.junit.jupiter.api.Assertions.*;
 
 class UserTest {
@@ -110,12 +112,12 @@ class UserTest {
     void updateProfileImageUrl_blank_throws() {
         User user = newUser();
 
-        BusinessException ex = assertThrows(
-                BusinessException.class,
-                () -> user.updateProfileImageUrl("   ")
-        );
+        Throwable thrown = catchThrowable(() -> user.updateProfileImageUrl("   "));
 
-        assertEquals(ErrorCode.INVALID_INPUT_VALUE, ex.getErrorCode());
+        Assertions.assertThat(thrown)
+                .isInstanceOf(BusinessException.class)
+                .extracting(ex -> ((BusinessException) ex).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_INPUT_VALUE);
     }
 
     @Test


### PR DESCRIPTION
## PR 개요

인증 흐름을 리팩토링하여 관심사 분리를 강화하고 Race Condition 방지합니다.
TokenResponder` 도입, Refresh Token ID 구조 개편(TSID 기반), 커스텀 보안 핸들러 추가, DTO 및 서비스 로직 정리


## 변경 사항

- [ ] 기능 추가
- [ ] 버그 수정
- [x] 리팩토링
- [x] 문서 수정
- [ ] 기타 ( )

**상세 내용**
- `TokenResponder` 도입
  토큰 응답 포맷팅 및 쿠키 설정을 전담하는 컴포넌트를 추가
  기존 `AuthService`, `AuthController`가 직접 쿠키를 다루던 로직을 제거하고, 책임을 `TokenResponder`로 분리
- RefreshToken의 ID를 UUID → TSID(Long)로 변경
- 'RefreshTokenIdGenerator`를 새로 추가하여 리프레시 토큰의 TSID ID 생성을 담당
- 인증 실패(401) 및 접근 거부(403)에 대해 일관된 JSON 형태의 에러 응답을 제공하는 핸들러 추가
- SecurityPaths 파일 추가

- service, controller, jwt 관련 테스트 코드 작성
- TestEntityFactory, TestFixtures를 이용한 중복 테스트 코드 제거

---





